### PR TITLE
fix: the restore wrongly calculate the commitment of SigLocked output

### DIFF
--- a/libwallet/src/internal/restore.rs
+++ b/libwallet/src/internal/restore.rs
@@ -20,6 +20,7 @@ use crate::gotts_core::global;
 use crate::gotts_core::libtx::proof;
 use crate::gotts_keychain::{ExtKeychain, Identifier, Keychain};
 use crate::gotts_util::secp::{pedersen, SecretKey};
+use crate::gotts_util::to_hex;
 use crate::internal::{keys, updater};
 use crate::types::*;
 use crate::{Error, OutputCommitMapping};
@@ -193,7 +194,7 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	let commit = wallet.calc_commit_for_cache(output.w, &output.key_id)?;
+	let commit = Some(to_hex(output.commit.0.to_vec()));
 	let mut batch = wallet.batch()?;
 
 	let parent_key_id = output.key_id.parent_path();


### PR DESCRIPTION
The `SigLocked` output is not the result of `r*G + w*H`, so can't use `wallet.calc_commit_for_cache(output.w, &output.key_id)`.

Instead, it's the `q*G + w*H`, where `q` is the `ephemeral_key`. Refer to document here: https://github.com/gottstech/gotts/blob/master/docs/intro.md#gotts-non-interactive-transaction.


