### PR TITLE
fix: the wallet check should ignore those txs which just created

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1337,6 +1337,9 @@ where
 	/// will happen if this flag is set. Note that if transactions/outputs are removed that later
 	/// confirm on the chain, another call to this function will restore them.
 	///
+	/// * `ignore_within` - ignore checking the txs which just happened within this specified minutes,
+	/// if 0, check all txs including recent Spent and Locked output; proposed value is 30 minutes.
+	///
 	/// # Returns
 	/// * `Ok(())` if successful
 	/// * or [`libwallet::Error`](../gotts_wallet_libwallet/struct.Error.html) if an error is encountered.
@@ -1349,6 +1352,7 @@ where
 	/// let mut api_owner = Owner::new(wallet.clone());
 	/// let result = api_owner.check_repair(
 	/// 	false,
+	///     30,
 	/// );
 	///
 	/// if let Ok(_) = result {
@@ -1357,10 +1361,10 @@ where
 	/// }
 	/// ```
 
-	pub fn check_repair(&self, delete_unconfirmed: bool) -> Result<(), Error> {
+	pub fn check_repair(&self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
-		let res = owner::check_repair(&mut *w, delete_unconfirmed);
+		let res = owner::check_repair(&mut *w, delete_unconfirmed, ignore_within);
 		w.close()?;
 		res
 	}
@@ -1370,6 +1374,8 @@ where
 	/// # Arguments
 	///
 	/// * `delete_unconfirmed` - same as in `check_repair`
+	///
+	/// * `ignore_within` - same as in `check_repair`
 	///
 	/// * `start_index` - the UTXO sets PMMR start index
 	///
@@ -1391,7 +1397,7 @@ where
 	///
 	/// let mut api_owner = Owner::new(wallet.clone());
 	/// let result = api_owner.check_repair_batch(
-	/// 	false, 1, 1000, true
+	/// 	false, 30, 1, 1000, true
 	/// );
 	///
 	/// if let Ok((highest_index, last_retrieved_index)) = result {
@@ -1402,6 +1408,7 @@ where
 	pub fn check_repair_batch(
 		&self,
 		delete_unconfirmed: bool,
+		ignore_within: u64,
 		start_index: u64,
 		batch_size: u64,
 		is_update_outputs: bool,
@@ -1411,6 +1418,7 @@ where
 		let res = owner::check_repair_batch(
 			&mut *w,
 			delete_unconfirmed,
+			ignore_within,
 			start_index,
 			batch_size,
 			is_update_outputs,

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1431,7 +1431,7 @@ pub trait OwnerRpc {
 	{
 		"jsonrpc": "2.0",
 		"method": "check_repair",
-		"params": [false],
+		"params": [false, 30],
 		"id": 1
 	}
 	# "#
@@ -1448,7 +1448,7 @@ pub trait OwnerRpc {
 	# , 1, false, false, false);
 	```
 	 */
-	fn check_repair(&self, delete_unconfirmed: bool) -> Result<(), ErrorKind>;
+	fn check_repair(&self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::node_height](struct.Owner.html#method.node_height).
@@ -1598,8 +1598,8 @@ where
 		Owner::restore(self).map_err(|e| e.kind())
 	}
 
-	fn check_repair(&self, delete_unconfirmed: bool) -> Result<(), ErrorKind> {
-		Owner::check_repair(self, delete_unconfirmed).map_err(|e| e.kind())
+	fn check_repair(&self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), ErrorKind> {
+		Owner::check_repair(self, delete_unconfirmed, ignore_within).map_err(|e| e.kind())
 	}
 
 	fn node_height(&self) -> Result<NodeHeightResult, ErrorKind> {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -920,6 +920,7 @@ pub fn restore(
 /// wallet check
 pub struct CheckArgs {
 	pub delete_unconfirmed: bool,
+	pub ignore_within: u64,
 }
 
 pub fn check_repair(
@@ -927,9 +928,13 @@ pub fn check_repair(
 	args: CheckArgs,
 ) -> Result<(), Error> {
 	controller::owner_single_use(wallet.clone(), |api| {
-		info!("Starting wallet check...",);
+		if args.ignore_within > 0 {
+			info!("Starting wallet check... (but ignore recent txs which just happened within {} minutes.)", args.ignore_within);
+		} else {
+			info!("Starting wallet check...", );
+		}
 		info!("Updating all wallet outputs, please wait ...",);
-		let result = api.check_repair(args.delete_unconfirmed);
+		let result = api.check_repair(args.delete_unconfirmed, args.ignore_within);
 		match result {
 			Ok(_) => {
 				info!("Wallet check complete",);

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -931,7 +931,7 @@ pub fn check_repair(
 		if args.ignore_within > 0 {
 			info!("Starting wallet check... (but ignore recent txs which just happened within {} minutes.)", args.ignore_within);
 		} else {
-			info!("Starting wallet check...", );
+			info!("Starting wallet check...",);
 		}
 		info!("Updating all wallet outputs, please wait ...",);
 		let result = api.check_repair(args.delete_unconfirmed, args.ignore_within);

--- a/controller/tests/check.rs
+++ b/controller/tests/check.rs
@@ -165,7 +165,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// this should restore our missing outputs
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check_repair(true)?;
+		api.check_repair(true, 0)?;
 		Ok(())
 	})?;
 
@@ -207,7 +207,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// unlock/restore
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check_repair(true)?;
+		api.check_repair(true, 0)?;
 		Ok(())
 	})?;
 
@@ -349,7 +349,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// 0) Check repair when all is okay should leave wallet contents alone
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check_repair(true)?;
+		api.check_repair(true, 0)?;
 		let info = wallet_info!(wallet1.clone())?;
 		assert_eq!(info.amount_currently_spendable, base_amount * 6);
 		assert_eq!(info.total, base_amount * 6);
@@ -394,7 +394,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// 2) check_repair should recover them into a single wallet
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check_repair(true)?;
+		api.check_repair(true, 0)?;
 		Ok(())
 	})?;
 
@@ -456,7 +456,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	})?;
 
 	wallet::controller::owner_single_use(wallet6.clone(), |api| {
-		api.check_repair(true)?;
+		api.check_repair(true, 0)?;
 		Ok(())
 	})?;
 
@@ -540,7 +540,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 3);
 		assert_eq!(info.amount_currently_spendable, base_amount * 15);
-		api.check_repair(true)?;
+		api.check_repair(true, 0)?;
 		let info = wallet_info!(wallet9.clone())?;
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 6);
@@ -558,7 +558,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// 7) Ensure check_repair creates missing accounts
 	wallet::controller::owner_single_use(wallet10.clone(), |api| {
-		api.check_repair(true)?;
+		api.check_repair(true, 0)?;
 		api.set_active_account("account_1")?;
 		let info = wallet_info!(wallet10.clone())?;
 		let outputs = api.retrieve_outputs(true, false, None)?.1;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -402,7 +402,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 	// check wallet2 can restore this output
 	let amount = 190_000_000_000;
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.check_repair(false).unwrap();
+		api.check_repair(false, 0).unwrap();
 		let (_, outputs_commit_map) = api.retrieve_outputs(false, true, None)?;
 		println!(
 			"wallet2 retrieve outputs: {}",
@@ -583,7 +583,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 	// check wallet2 can restore this output
 	let amount = 263_000_000_000;
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.check_repair(false).unwrap();
+		api.check_repair(false, 0).unwrap();
 		let (_, outputs_commit_map) = api.retrieve_outputs(false, true, None)?;
 		println!(
 			"wallet2 retrieve outputs: {}",

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -514,8 +514,14 @@ where
 		start_index: u64,
 		batch_size: u64,
 	) -> Result<(u64, u64), Error> {
-		let res = check_repair_batch(self, delete_unconfirmed, ignore_within, start_index, batch_size)
-			.context(ErrorKind::Restore)?;
+		let res = check_repair_batch(
+			self,
+			delete_unconfirmed,
+			ignore_within,
+			start_index,
+			batch_size,
+		)
+		.context(ErrorKind::Restore)?;
 		Ok(res)
 	}
 }

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -502,18 +502,19 @@ where
 		Ok(res)
 	}
 
-	fn check_repair(&mut self, delete_unconfirmed: bool) -> Result<(), Error> {
-		check_repair(self, delete_unconfirmed).context(ErrorKind::Restore)?;
+	fn check_repair(&mut self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error> {
+		check_repair(self, delete_unconfirmed, ignore_within).context(ErrorKind::Restore)?;
 		Ok(())
 	}
 
 	fn check_repair_batch(
 		&mut self,
 		delete_unconfirmed: bool,
+		ignore_within: u64,
 		start_index: u64,
 		batch_size: u64,
 	) -> Result<(u64, u64), Error> {
-		let res = check_repair_batch(self, delete_unconfirmed, start_index, batch_size)
+		let res = check_repair_batch(self, delete_unconfirmed, ignore_within, start_index, batch_size)
 			.context(ErrorKind::Restore)?;
 		Ok(res)
 	}

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -641,20 +641,21 @@ where
 }
 
 /// check repair
-pub fn check_repair<T: ?Sized, C, K>(w: &mut T, delete_unconfirmed: bool) -> Result<(), Error>
+pub fn check_repair<T: ?Sized, C, K>(w: &mut T, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
 	K: Keychain,
 {
 	update_outputs(w, true);
-	w.check_repair(delete_unconfirmed)
+	w.check_repair(delete_unconfirmed, ignore_within)
 }
 
 /// check repair
 pub fn check_repair_batch<T: ?Sized, C, K>(
 	w: &mut T,
 	delete_unconfirmed: bool,
+	ignore_within: u64,
 	start_index: u64,
 	batch_size: u64,
 	is_update_outputs: bool,
@@ -667,7 +668,7 @@ where
 	if is_update_outputs {
 		update_outputs(w, true);
 	}
-	w.check_repair_batch(delete_unconfirmed, start_index, batch_size)
+	w.check_repair_batch(delete_unconfirmed, ignore_within, start_index, batch_size)
 }
 
 /// node height

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -641,7 +641,11 @@ where
 }
 
 /// check repair
-pub fn check_repair<T: ?Sized, C, K>(w: &mut T, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error>
+pub fn check_repair<T: ?Sized, C, K>(
+	w: &mut T,
+	delete_unconfirmed: bool,
+	ignore_within: u64,
+) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,

--- a/libwallet/src/internal/restore.rs
+++ b/libwallet/src/internal/restore.rs
@@ -341,13 +341,16 @@ where
 		match matched_out {
 			Some(s) => {
 				let mut is_waiting_confirm = false;
-				if ignore_within != 0 {	// 0 means 'checking all txs'.
+				if ignore_within != 0 {
+					// 0 means 'checking all txs'.
 					if let Some(tx_log_entry) = s.output.tx_log_entry {
 						if outstanding_txs_id.contains(&tx_log_entry) {
 							let tx_log = tx_vec.iter().find(|e| e.id == tx_log_entry).unwrap();
 							// let's ignore the checking on the txs which just happened within 30 minutes, which could still stay in tx pool and wait
 							// for packaging into a block.
-							if tx_log.creation_ts + Duration::minutes(ignore_within as i64) > Utc::now() {
+							if tx_log.creation_ts + Duration::minutes(ignore_within as i64)
+								> Utc::now()
+							{
 								is_waiting_confirm = true;
 							}
 						}
@@ -455,7 +458,11 @@ where
 /// Check / repair wallet contents
 /// assume wallet contents have been freshly updated with contents
 /// of latest block
-pub fn check_repair<T, C, K>(wallet: &mut T, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error>
+pub fn check_repair<T, C, K>(
+	wallet: &mut T,
+	delete_unconfirmed: bool,
+	ignore_within: u64,
+) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -164,12 +164,13 @@ where
 	) -> Result<(u64, u64, u64), Error>;
 
 	/// Attempt to check and fix wallet state
-	fn check_repair(&mut self, delete_unconfirmed: bool) -> Result<(), Error>;
+	fn check_repair(&mut self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error>;
 
 	/// Attempt to check and fix wallet state, by index on batch
 	fn check_repair_batch(
 		&mut self,
 		delete_unconfirmed: bool,
+		ignore_within: u64,
 		start_index: u64,
 		batch_size: u64,
 	) -> Result<(u64, u64), Error>;

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -747,8 +747,15 @@ pub fn parse_info_args(args: &ArgMatches) -> Result<command::InfoArgs, ParseErro
 
 pub fn parse_check_args(args: &ArgMatches) -> Result<command::CheckArgs, ParseError> {
 	let delete_unconfirmed = args.is_present("delete_unconfirmed");
+	let ignore_within = parse_required(args, "ignore_within")?;
+	let mut ignore_within = parse_u64(ignore_within, "ignore_within")?;
+	// Valid range: [0..1440]. Unit: Minute.
+	if ignore_within > 1440 {
+		ignore_within = 1440;
+	}
 	Ok(command::CheckArgs {
-		delete_unconfirmed: delete_unconfirmed,
+		delete_unconfirmed,
+		ignore_within,
 	})
 }
 

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -451,7 +451,7 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
-		let arg_vec = vec!["gotts-wallet", "-p", "password", "check", "-d"];
+		let arg_vec = vec!["gotts-wallet", "-p", "password", "check", "-d", "-i", "0"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
 		// Another file exchange, cancel this time

--- a/src/bin/gotts-wallet.yml
+++ b/src/bin/gotts-wallet.yml
@@ -370,6 +370,12 @@ subcommands:
             short: d
             long: delete_unconfirmed
             takes_value: false
+        - ignore_within:
+            help: Ignore recent transactions within the specified minutes. Default ignore txs within 30 minutes; Check all txs if 0. Valid range [0, 1440].
+            short: i
+            long: ignore_within
+            default_value: "30"
+            takes_value: true
   - passwd:
       about: Changing password for wallet.
   - address:


### PR DESCRIPTION
fix for https://github.com/gottstech/gotts-wallet/issues/9

`check` command should ignore those txs which was just created, let's set a hardcoded threshold as `30 minutes` at this moment, to have some time for the chain to take the corresponding transactions into a block.

i.e., after this PR, the `check` command will **not** work on the txs created within 30 minutes.