### PR TITLE
cli: enhance the 'address' command

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1576,7 +1576,7 @@ macro_rules! doctest_helper_setup_doc_env {
 		use gotts_wallet_util::gotts_keychain as keychain;
 		use gotts_wallet_util::gotts_util as util;
 
-		use keychain::ExtKeychain;
+		use keychain::{ExtKeychain, ExtKeychainPath};
 		use tempfile::tempdir;
 
 		use std::sync::Arc;

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -715,6 +715,38 @@ where
 		Ok(recipient_key)
 	}
 
+	/// Get the wallet receiving key for the non-interactive transaction, by a specified key id.
+	///
+	/// # Returns
+	/// * ``Ok([`RecipientKey`](../gotts_keychain/RecipientKey/struct.RecipientKey.html))` if successful,
+	/// containing the updated slate.
+	/// * or [`libwallet::Error`](../gotts_wallet_libwallet/struct.Error.html) if an error is encountered.
+	///
+	/// # Example
+	/// Set up as in [`new`](struct.Owner.html#method.new) method above.
+	/// ```
+	/// # gotts_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
+	///
+	/// let mut api_owner = Owner::new(wallet.clone());
+	///
+	/// let key_id =
+	///		ExtKeychainPath::new(4, <u32>::max_value(), <u32>::max_value(), 0, 100).to_identifier();
+	///
+	/// let result = api_owner.get_recipient_key_by_id(&key_id);
+	///
+	/// if let Ok(recipient_key) = result {
+	///		// if okay, convert it to Address and get the string address to tell the payer.
+	///		// . . .
+	/// }
+	/// ```
+	pub fn get_recipient_key_by_id(&self, key_id: &Identifier) -> Result<RecipientKey, Error> {
+		let mut w = self.wallet.lock();
+		w.open_with_credentials()?;
+		let recipient_key = owner::get_recipient_key_by_id(&mut *w, key_id)?;
+		w.close()?;
+		Ok(recipient_key)
+	}
+
 	/// Issues a new invoice transaction slate, essentially a `request for payment`.
 	/// The slate created by this function will contain the amount, an output for the amount,
 	/// as well as round 1 of singature creation complete. The slate should then be send

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -228,6 +228,22 @@ where
 		})
 	}
 
+	fn recipient_key_by_id(&self, key_id: &Identifier) -> Result<RecipientKey, Error> {
+		if self.keychain.is_none() {
+			return Err(ErrorKind::Backend("keychain is none".to_string()).into());
+		}
+
+		let keychain = self.keychain_immutable();
+		let recipient_pri_key = keychain.derive_key(key_id).unwrap();
+		let recipient_pub_key =
+			PublicKey::from_secret_key(keychain.secp(), &recipient_pri_key).unwrap();
+		Ok(RecipientKey {
+			recipient_key_id: key_id.clone(),
+			recipient_pub_key,
+			recipient_pri_key,
+		})
+	}
+
 	/// Close wallet and remove any stored credentials (TBD)
 	fn close(&mut self) -> Result<(), Error> {
 		self.keychain = None;

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -249,6 +249,19 @@ where
 	w.recipient_key()
 }
 
+/// Get the recipient key for non-interactive transaction, by a specified key id
+pub fn get_recipient_key_by_id<T: ?Sized, C, K>(
+	w: &mut T,
+	key_id: &Identifier,
+) -> Result<RecipientKey, Error>
+where
+	T: WalletBackend<C, K>,
+	C: NodeClient,
+	K: Keychain,
+{
+	w.recipient_key_by_id(key_id)
+}
+
 /// Construction of a non-interactive transaction output
 pub fn create_non_interactive_output<T: ?Sized, C, K>(
 	w: &mut T,

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -66,6 +66,9 @@ where
 	/// Return the recipient key
 	fn recipient_key(&self) -> Result<RecipientKey, Error>;
 
+	/// Return a recipient key by the key id
+	fn recipient_key_by_id(&self, key_id: &Identifier) -> Result<RecipientKey, Error>;
+
 	/// Close wallet and remove any stored credentials (TBD)
 	fn close(&mut self) -> Result<(), Error>;
 

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -446,6 +446,15 @@ pub fn parse_recover_args(
 	})
 }
 
+pub fn parse_address_args(args: &ArgMatches) -> Result<command::AddressArgs, ParseError> {
+	let address_to_check = if let Ok(addr) = parse_required(args, "check") {
+		Some(addr.to_string())
+	} else {
+		None
+	};
+	Ok(command::AddressArgs { address_to_check })
+}
+
 pub fn parse_listen_args(
 	config: &mut WalletConfig,
 	g_args: &mut command::GlobalArgs,
@@ -1020,7 +1029,10 @@ pub fn wallet_command(
 				wallet_config.dark_background_color_scheme.unwrap_or(true),
 			)
 		}
-		("address", Some(_)) => command::address(inst_wallet()),
+		("address", Some(args)) => {
+			let a = arg_parse!(parse_address_args(&args));
+			command::address(inst_wallet(), a)
+		}
 		("repost", Some(args)) => {
 			let a = arg_parse!(parse_repost_args(&args));
 			command::repost(inst_wallet(), a)

--- a/src/bin/gotts-wallet.yml
+++ b/src/bin/gotts-wallet.yml
@@ -380,3 +380,9 @@ subcommands:
       about: Changing password for wallet.
   - address:
       about: Query current Gotts receiving address for wallet.
+      args:
+        - check:
+            help: Check the address info
+            short: c
+            long: check
+            takes_value: true


### PR DESCRIPTION
The `gotts-wallet address` command is used to query the wallet recipient address which currently using.

Sometimes, we need to check the info of an address, which could be issued by this wallet sometime ago, or someone else.

The new `address --check xxx` command is designed for that.

The usage example:
```sh
$ gotts-wallet --floonet address -c gs1qq0lrhergam6qthzwnkw484uf98geecnrsuc4l46amn6c2qzmnalvzkul0mqsyjn27h

The Gotts address info: 
	PublicKey = 036808199c913b6adb1ec83eeabd490ad1ca92b8a0820214e5e2b30d50fb893a05, 
	keypath = 04ffffffffffffffff0000000000000001, 
	pkh = 23ea8bbd83a08bee6c581b6b06db29137ac3859999023859aa9030bf1a34ebe1, 
It's the address owned by this wallet.
Command 'address' completed successfully


$ gotts-wallet --pass 338517 --floonet address -c gs1qq0lrhergam6qthzwnkw484uf98geecnrsuc4l46amn6c2qzmnalvzkul0mqsyjn27h

The Gotts address info: 
	PublicKey = 03fe3be468eef405dc4e9d9d53d78929d19ce26387315fd75ddcf585005b9f7ec1, 
	keypath = 04ffffffffffffffff0000000000000000, 
	pkh = bda91efdc1bcca84d187bd9843e5b8b83d053e1281307583ff019b0e1e7fa049, 
It's the address not owned by this wallet.
Command 'address' completed successfully
```

For querying the current address of this wallet:
```sh
$ gotts-wallet --floonet address

Your current Gotts address for receiving: gs1qqtsxd0paccglqtl6mzlu82srgmh4e6a9vp4qet4g3g7fkrmt6vjgg67nyjrq0hwv4a
Command 'address' completed successfully
```

