### PR TITLE
check and collect non-interactive transaction outputs from the chain

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1380,6 +1380,9 @@ where
 	/// * `ignore_within` - ignore checking the txs which just happened within this specified minutes,
 	/// if 0, check all txs including recent Spent and Locked output; proposed value is 30 minutes.
 	///
+	/// * `address_to_check` - if `Some(String)`, only checking the non-interactive transaction outputs
+	/// which exist on the chain but missing in the local wallet.
+	///
 	/// # Returns
 	/// * `Ok(())` if successful
 	/// * or [`libwallet::Error`](../gotts_wallet_libwallet/struct.Error.html) if an error is encountered.
@@ -1393,6 +1396,7 @@ where
 	/// let result = api_owner.check_repair(
 	/// 	false,
 	///     30,
+	/// 	None,
 	/// );
 	///
 	/// if let Ok(_) = result {
@@ -1401,10 +1405,15 @@ where
 	/// }
 	/// ```
 
-	pub fn check_repair(&self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error> {
+	pub fn check_repair(
+		&self,
+		delete_unconfirmed: bool,
+		ignore_within: u64,
+		address_to_check: Option<String>,
+	) -> Result<(), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
-		let res = owner::check_repair(&mut *w, delete_unconfirmed, ignore_within);
+		let res = owner::check_repair(&mut *w, delete_unconfirmed, ignore_within, address_to_check);
 		w.close()?;
 		res
 	}
@@ -1426,6 +1435,9 @@ where
 	/// one time of update_outputs() in a whole check_repair_batch procedure. Only set this parameter
 	/// as `true` in the 1st call of this function in a check_repair_batch procedure.
 	///
+	/// * `address_to_check` - if `Some(String)`, only checking the non-interactive transaction outputs
+	/// which exist on the chain but missing in the local wallet.
+	///
 	/// # Returns
 	/// * `Ok((highest_index, last_retrieved_index))` if successful
 	/// * or [`libwallet::Error`](../gotts_wallet_libwallet/struct.Error.html) if an error is encountered.
@@ -1437,7 +1449,7 @@ where
 	///
 	/// let mut api_owner = Owner::new(wallet.clone());
 	/// let result = api_owner.check_repair_batch(
-	/// 	false, 30, 1, 1000, true
+	/// 	false, 30, 1, 1000, true, None
 	/// );
 	///
 	/// if let Ok((highest_index, last_retrieved_index)) = result {
@@ -1452,6 +1464,7 @@ where
 		start_index: u64,
 		batch_size: u64,
 		is_update_outputs: bool,
+		address_to_check: Option<String>,
 	) -> Result<(u64, u64), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
@@ -1462,6 +1475,7 @@ where
 			start_index,
 			batch_size,
 			is_update_outputs,
+			address_to_check,
 		);
 		w.close()?;
 		res

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1431,7 +1431,7 @@ pub trait OwnerRpc {
 	{
 		"jsonrpc": "2.0",
 		"method": "check_repair",
-		"params": [false, 30],
+		"params": [false, 30, null],
 		"id": 1
 	}
 	# "#
@@ -1448,7 +1448,12 @@ pub trait OwnerRpc {
 	# , 1, false, false, false);
 	```
 	 */
-	fn check_repair(&self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), ErrorKind>;
+	fn check_repair(
+		&self,
+		delete_unconfirmed: bool,
+		ignore_within: u64,
+		address_to_check: Option<String>,
+	) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::node_height](struct.Owner.html#method.node_height).
@@ -1598,8 +1603,14 @@ where
 		Owner::restore(self).map_err(|e| e.kind())
 	}
 
-	fn check_repair(&self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), ErrorKind> {
-		Owner::check_repair(self, delete_unconfirmed, ignore_within).map_err(|e| e.kind())
+	fn check_repair(
+		&self,
+		delete_unconfirmed: bool,
+		ignore_within: u64,
+		address_to_check: Option<String>,
+	) -> Result<(), ErrorKind> {
+		Owner::check_repair(self, delete_unconfirmed, ignore_within, address_to_check)
+			.map_err(|e| e.kind())
 	}
 
 	fn node_height(&self) -> Result<NodeHeightResult, ErrorKind> {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -952,6 +952,7 @@ pub fn restore(
 pub struct CheckArgs {
 	pub delete_unconfirmed: bool,
 	pub ignore_within: u64,
+	pub address_to_check: Option<String>,
 }
 
 pub fn check_repair(
@@ -965,7 +966,11 @@ pub fn check_repair(
 			info!("Starting wallet check...",);
 		}
 		info!("Updating all wallet outputs, please wait ...",);
-		let result = api.check_repair(args.delete_unconfirmed, args.ignore_within);
+		let result = api.check_repair(
+			args.delete_unconfirmed,
+			args.ignore_within,
+			args.address_to_check,
+		);
 		match result {
 			Ok(_) => {
 				info!("Wallet check complete",);

--- a/controller/tests/check.rs
+++ b/controller/tests/check.rs
@@ -165,7 +165,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// this should restore our missing outputs
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check_repair(true, 0)?;
+		api.check_repair(true, 0, None)?;
 		Ok(())
 	})?;
 
@@ -207,7 +207,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// unlock/restore
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check_repair(true, 0)?;
+		api.check_repair(true, 0, None)?;
 		Ok(())
 	})?;
 
@@ -349,7 +349,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// 0) Check repair when all is okay should leave wallet contents alone
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check_repair(true, 0)?;
+		api.check_repair(true, 0, None)?;
 		let info = wallet_info!(wallet1.clone())?;
 		assert_eq!(info.amount_currently_spendable, base_amount * 6);
 		assert_eq!(info.total, base_amount * 6);
@@ -394,7 +394,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// 2) check_repair should recover them into a single wallet
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.check_repair(true, 0)?;
+		api.check_repair(true, 0, None)?;
 		Ok(())
 	})?;
 
@@ -456,7 +456,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	})?;
 
 	wallet::controller::owner_single_use(wallet6.clone(), |api| {
-		api.check_repair(true, 0)?;
+		api.check_repair(true, 0, None)?;
 		Ok(())
 	})?;
 
@@ -540,7 +540,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 3);
 		assert_eq!(info.amount_currently_spendable, base_amount * 15);
-		api.check_repair(true, 0)?;
+		api.check_repair(true, 0, None)?;
 		let info = wallet_info!(wallet9.clone())?;
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 6);
@@ -558,7 +558,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// 7) Ensure check_repair creates missing accounts
 	wallet::controller::owner_single_use(wallet10.clone(), |api| {
-		api.check_repair(true, 0)?;
+		api.check_repair(true, 0, None)?;
 		api.set_active_account("account_1")?;
 		let info = wallet_info!(wallet10.clone())?;
 		let outputs = api.retrieve_outputs(true, false, None)?.1;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -402,7 +402,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 	// check wallet2 can restore this output
 	let amount = 190_000_000_000;
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.check_repair(false, 0).unwrap();
+		api.check_repair(false, 0, None).unwrap();
 		let (_, outputs_commit_map) = api.retrieve_outputs(false, true, None)?;
 		println!(
 			"wallet2 retrieve outputs: {}",
@@ -583,7 +583,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 	// check wallet2 can restore this output
 	let amount = 263_000_000_000;
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.check_repair(false, 0).unwrap();
+		api.check_repair(false, 0, None).unwrap();
 		let (_, outputs_commit_map) = api.retrieve_outputs(false, true, None)?;
 		println!(
 			"wallet2 retrieve outputs: {}",

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -518,8 +518,14 @@ where
 		Ok(res)
 	}
 
-	fn check_repair(&mut self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error> {
-		check_repair(self, delete_unconfirmed, ignore_within).context(ErrorKind::Restore)?;
+	fn check_repair(
+		&mut self,
+		delete_unconfirmed: bool,
+		ignore_within: u64,
+		address_to_check: Option<String>,
+	) -> Result<(), Error> {
+		check_repair(self, delete_unconfirmed, ignore_within, address_to_check)
+			.context(ErrorKind::Restore)?;
 		Ok(())
 	}
 
@@ -529,6 +535,7 @@ where
 		ignore_within: u64,
 		start_index: u64,
 		batch_size: u64,
+		address_to_check: Option<String>,
 	) -> Result<(u64, u64), Error> {
 		let res = check_repair_batch(
 			self,
@@ -536,6 +543,7 @@ where
 			ignore_within,
 			start_index,
 			batch_size,
+			address_to_check,
 		)
 		.context(ErrorKind::Restore)?;
 		Ok(res)

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -505,7 +505,7 @@ where
 	}
 
 	fn restore(&mut self) -> Result<(), Error> {
-		restore(self).context(ErrorKind::Restore)?;
+		restore(self)?;
 		Ok(())
 	}
 
@@ -514,7 +514,7 @@ where
 		start_index: u64,
 		batch_size: u64,
 	) -> Result<(u64, u64, u64), Error> {
-		let res = restore_batch(self, start_index, batch_size).context(ErrorKind::Restore)?;
+		let res = restore_batch(self, start_index, batch_size)?;
 		Ok(res)
 	}
 
@@ -524,8 +524,7 @@ where
 		ignore_within: u64,
 		address_to_check: Option<String>,
 	) -> Result<(), Error> {
-		check_repair(self, delete_unconfirmed, ignore_within, address_to_check)
-			.context(ErrorKind::Restore)?;
+		check_repair(self, delete_unconfirmed, ignore_within, address_to_check)?;
 		Ok(())
 	}
 
@@ -544,8 +543,7 @@ where
 			start_index,
 			batch_size,
 			address_to_check,
-		)
-		.context(ErrorKind::Restore)?;
+		)?;
 		Ok(res)
 	}
 }

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -230,6 +230,7 @@ impl NodeClient for HTTPNodeClient {
 		&self,
 		start_height: u64,
 		max_outputs: u64,
+		nit_only: bool,
 	) -> Result<
 		(
 			u64,
@@ -241,7 +242,11 @@ impl NodeClient for HTTPNodeClient {
 		let addr = self.node_url();
 		let query_param = format!("start_index={}&max={}", start_height, max_outputs);
 
-		let url = format!("{}/v1/txhashset/outputs?{}", addr, query_param,);
+		let url = if !nit_only {
+			format!("{}/v1/txhashset/outputs?{}", addr, query_param)
+		} else {
+			format!("{}/v1/txhashset/nit-outputs?{}", addr, query_param)
+		};
 
 		let mut api_outputs: Vec<(pedersen::Commitment, Output, bool, u64, u64)> = Vec::new();
 

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -553,6 +553,7 @@ impl NodeClient for LocalWalletClient {
 		&self,
 		start_height: u64,
 		max_outputs: u64,
+		_nit_only: bool,
 	) -> Result<
 		(
 			u64,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -658,6 +658,7 @@ pub fn check_repair<T: ?Sized, C, K>(
 	w: &mut T,
 	delete_unconfirmed: bool,
 	ignore_within: u64,
+	address_to_check: Option<String>,
 ) -> Result<(), Error>
 where
 	T: WalletBackend<C, K>,
@@ -665,7 +666,7 @@ where
 	K: Keychain,
 {
 	update_outputs(w, true);
-	w.check_repair(delete_unconfirmed, ignore_within)
+	w.check_repair(delete_unconfirmed, ignore_within, address_to_check)
 }
 
 /// check repair
@@ -676,6 +677,7 @@ pub fn check_repair_batch<T: ?Sized, C, K>(
 	start_index: u64,
 	batch_size: u64,
 	is_update_outputs: bool,
+	address_to_check: Option<String>,
 ) -> Result<(u64, u64), Error>
 where
 	T: WalletBackend<C, K>,
@@ -685,7 +687,13 @@ where
 	if is_update_outputs {
 		update_outputs(w, true);
 	}
-	w.check_repair_batch(delete_unconfirmed, ignore_within, start_index, batch_size)
+	w.check_repair_batch(
+		delete_unconfirmed,
+		ignore_within,
+		start_index,
+		batch_size,
+		address_to_check,
+	)
 }
 
 /// node height

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -167,7 +167,12 @@ where
 	) -> Result<(u64, u64, u64), Error>;
 
 	/// Attempt to check and fix wallet state
-	fn check_repair(&mut self, delete_unconfirmed: bool, ignore_within: u64) -> Result<(), Error>;
+	fn check_repair(
+		&mut self,
+		delete_unconfirmed: bool,
+		ignore_within: u64,
+		address_to_check: Option<String>,
+	) -> Result<(), Error>;
 
 	/// Attempt to check and fix wallet state, by index on batch
 	fn check_repair_batch(
@@ -176,6 +181,7 @@ where
 		ignore_within: u64,
 		start_index: u64,
 		batch_size: u64,
+		address_to_check: Option<String>,
 	) -> Result<(u64, u64), Error>;
 }
 
@@ -300,15 +306,16 @@ pub trait NodeClient: Sync + Send + Clone {
 		wallet_kernels_keys: Vec<String>,
 	) -> Result<HashMap<pedersen::Commitment, TxKernelApiEntry>, Error>;
 
-	/// Get a list of outputs from the node by traversing the UTXO
-	/// set in PMMR index order.
-	/// Returns
+	/// Get a list of outputs from the node by traversing the UTXO set in PMMR index order.
+	/// Caller can set 'nit_only' as true for only Non-Interactive Outputs UTXO traversing.
+	/// Returns:
 	/// (last available output index, last insertion index retrieved,
 	/// outputs(commit, proof, is_coinbase, height, mmr_index))
 	fn get_outputs_by_pmmr_index(
 		&self,
 		start_height: u64,
 		max_outputs: u64,
+		nit_only: bool,
 	) -> Result<
 		(
 			u64,

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -762,9 +762,15 @@ pub fn parse_check_args(args: &ArgMatches) -> Result<command::CheckArgs, ParseEr
 	if ignore_within > 1440 {
 		ignore_within = 1440;
 	}
+	let address_to_check = if let Ok(addr) = parse_required(args, "address") {
+		Some(addr.to_string())
+	} else {
+		None
+	};
 	Ok(command::CheckArgs {
 		delete_unconfirmed,
 		ignore_within,
+		address_to_check,
 	})
 }
 

--- a/src/bin/gotts-wallet.yml
+++ b/src/bin/gotts-wallet.yml
@@ -376,6 +376,11 @@ subcommands:
             long: ignore_within
             default_value: "30"
             takes_value: true
+        - address:
+            help: Check the non-interactive transaction output on the specified address.
+            short: a
+            long: address
+            takes_value: true
   - passwd:
       about: Changing password for wallet.
   - address:


### PR DESCRIPTION
For non-interactive transaction receiver, he/she need manually run a `check` command to collect those outputs into his/her local wallet database.

The original `check` command will run on all UTXO sets.

This enhanced `check -a xxx` command will only traverse the non-interactive output UTXO sets, and collect the 'missed' outputs into the wallet.

The usage example:

```sh
gotts-wallet --floonet check -a ts1qqd5qsxvujyak4kc7eqlw402fptgu4y4c5zpqy989u2es658m3yaqt7uf8gzq8wyn24


1203 14:48:27 INFO - Checking 334 outputs, up to index 340. (Highest index: 340)
1203 14:48:28 INFO - SigLocked Output found: Commitment(085078302f89720b5ee2330c557d428f70b732165381f3892911dd5076b13732be), amount: 99900000000, key_id: Identifier(04ffffffffffffffff0000000000000001), mmr_index: 671,
1203 14:48:28 INFO - SigLocked Output found: Commitment(09b145313efa33e15d9706e22341dac919d9d82cce1c487b9b3f64d689dc5978f0), amount: 100000000, key_id: Identifier(04ffffffffffffffff0000000000000001), mmr_index: 673,
1203 14:48:28 INFO - collect_chain_outputs: 2 utxo outputs identified
1203 14:48:28 INFO - Identified 2 wallet_outputs as belonging to this wallet
1203 14:48:28 WARN - Confirmed output for 99900000000 with Identifier(04ffffffffffffffff0000000000000001) Commitment(085078302f89720b5ee2330c557d428f70b732165381f3892911dd5076b13732be) exists in UTXO set but not in wallet. Restoring.
1203 14:48:28 WARN - Confirmed output for 100000000 with Identifier(04ffffffffffffffff0000000000000001) Commitment(09b145313efa33e15d9706e22341dac919d9d82cce1c487b9b3f64d689dc5978f0) exists in UTXO set but not in wallet. Restoring.
1203 14:48:28 INFO - Repaired wallet in 0m0s
1203 14:48:28 INFO - Wallet check complete
Command 'check' completed successfully
```

after that, run `outputs` command to read them:
```sh
gotts-wallet --floonet outputs

Wallet Outputs - Account 'default' - Block Height: 2430
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Output Commitment                                                   MMR Index  Block Height  Locked Until  Status   Coinbase?  Change?  # Confirms  Value       Tx 
=====================================================================================================================================================================
 085078302f89720b5ee2330c557d428f70b732165381f3892911dd5076b13732be  671        2416          2416          Unspent  false               15          99.9        0 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 09b145313efa33e15d9706e22341dac919d9d82cce1c487b9b3f64d689dc5978f0  673        2416          2416          Unspent  false               15          0.1         1 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 085a8428c2bec47d9362cc8a72502ef0722937713498b90d7bf57518f434996500  None       2423          0             Unspent  false      true     8           42819.5509  727 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------

total displayed outputs: 3
Command 'outputs' completed successfully
```