### PR TITLE
fix: the windows travis-ci often fail on 'No space left on device'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,11 @@ matrix:
   - os: osx
     env: CI_JOB="release"     CI_JOB_ARGS=
   - os: windows
-    env: CI_JOB="test"        CI_JOB_ARGS="config libwallet api"
+    env: CI_JOB="test"        CI_JOB_ARGS="config"
+  - os: windows
+    env: CI_JOB="test"        CI_JOB_ARGS="libwallet"
+  - os: windows
+    env: CI_JOB="test"        CI_JOB_ARGS="api"
   - os: windows
     env: CI_JOB="test"        CI_JOB_ARGS="impls"
   - os: windows


### PR DESCRIPTION
try to fix by the workaound: splitting the "config libwallet api" into 3 tests instances.