### PR TITLE
Updated for PathMessage refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,18 +627,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "gotts_api"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?tag=v0.0.5#7d82c78d61e71a3817a63efc6d5b4db0898b2931"
+source = "git+https://github.com/gottstech/gotts?rev=1987486#19874865765303d3ea599a26088cb2b7951cb22a"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "gotts_chain"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?tag=v0.0.5#7d82c78d61e71a3817a63efc6d5b4db0898b2931"
+source = "git+https://github.com/gottstech/gotts?rev=1987486#19874865765303d3ea599a26088cb2b7951cb22a"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -668,10 +668,10 @@ dependencies = [
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "gotts_core"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?tag=v0.0.5#7d82c78d61e71a3817a63efc6d5b4db0898b2931"
+source = "git+https://github.com/gottstech/gotts?rev=1987486#19874865765303d3ea599a26088cb2b7951cb22a"
 dependencies = [
  "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -694,8 +694,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "gotts_keychain"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?tag=v0.0.5#7d82c78d61e71a3817a63efc6d5b4db0898b2931"
+source = "git+https://github.com/gottstech/gotts?rev=1987486#19874865765303d3ea599a26088cb2b7951cb22a"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -720,7 +720,7 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,16 +739,16 @@ dependencies = [
 [[package]]
 name = "gotts_p2p"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?tag=v0.0.5#7d82c78d61e71a3817a63efc6d5b4db0898b2931"
+source = "git+https://github.com/gottstech/gotts?rev=1987486#19874865765303d3ea599a26088cb2b7951cb22a"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -761,16 +761,16 @@ dependencies = [
 [[package]]
 name = "gotts_pool"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?tag=v0.0.5#7d82c78d61e71a3817a63efc6d5b4db0898b2931"
+source = "git+https://github.com/gottstech/gotts?rev=1987486#19874865765303d3ea599a26088cb2b7951cb22a"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -797,15 +797,15 @@ dependencies = [
 [[package]]
 name = "gotts_store"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?tag=v0.0.5#7d82c78d61e71a3817a63efc6d5b4db0898b2931"
+source = "git+https://github.com/gottstech/gotts?rev=1987486#19874865765303d3ea599a26088cb2b7951cb22a"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "gotts_util"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?tag=v0.0.5#7d82c78d61e71a3817a63efc6d5b4db0898b2931"
+source = "git+https://github.com/gottstech/gotts?rev=1987486#19874865765303d3ea599a26088cb2b7951cb22a"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -977,12 +977,12 @@ version = "0.0.5"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)",
+ "gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3002,15 +3002,15 @@ dependencies = [
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)" = "<none>"
-"checksum gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)" = "<none>"
-"checksum gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)" = "<none>"
-"checksum gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)" = "<none>"
-"checksum gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)" = "<none>"
-"checksum gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)" = "<none>"
+"checksum gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)" = "<none>"
+"checksum gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)" = "<none>"
+"checksum gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)" = "<none>"
+"checksum gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)" = "<none>"
+"checksum gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)" = "<none>"
+"checksum gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)" = "<none>"
 "checksum gotts_secp256k1zkp 0.7.10 (git+https://github.com/gottstech/rust-secp256k1-zkp?rev=51798f2)" = "<none>"
-"checksum gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)" = "<none>"
-"checksum gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?tag=v0.0.5)" = "<none>"
+"checksum gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)" = "<none>"
+"checksum gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1987486)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -102,7 +102,7 @@ pub trait ForeignRpc {
 					"commit": "08453117c78d6d9f2885602a843856b4737b3e0838b28b3f861c5082fbfa428c36",
 					"features": {
 					  "Coinbase": {
-						"spath": "ff776b7e9f6edb03aea68dce23493f012e0c0e267e052ecf0b0fb714"
+						"spath": "20883d598f1e9fa9498e29f8"
 					  }
 					},
 					"value": 60000000000
@@ -249,7 +249,7 @@ pub trait ForeignRpc {
 					{
 					  "features": {
 						"Plain": {
-						  "spath": "9e0f681afae46a92556f7086b1e6c2146effd2c8f2c25727946b249e"
+						  "spath": "dd1095c1ea0180f076c18bda"
 						}
 					  },
 					  "commit": "099af2fbafc88308fc210cf6341a443b90312f2dfb90b50cda0c7d1dc5d5a59c6e",
@@ -291,89 +291,89 @@ pub trait ForeignRpc {
 	# ,
 	# r#"
 	{
-		"id": 1,
-		"jsonrpc": "2.0",
-		"result": {
-			"Ok": {
-			  "amount": "60000000000",
-			  "fee": "7000000",
-			  "height": "5",
-			  "id": "0436430c-2b02-624c-2032-570501212b00",
-			  "lock_height": "0",
-			  "num_participants": 2,
-			  "participant_data": [
+	  "id": 1,
+	  "jsonrpc": "2.0",
+	  "result": {
+		"Ok": {
+		  "amount": "60000000000",
+		  "fee": "7000000",
+		  "height": "5",
+		  "id": "0436430c-2b02-624c-2032-570501212b00",
+		  "lock_height": "0",
+		  "num_participants": 2,
+		  "participant_data": [
+			{
+			  "id": "0",
+			  "message": null,
+			  "message_sig": null,
+			  "part_sig": null,
+			  "public_blind_excess": "020e44132261fcdc9112d1bae25ab54d9c00609353cb23143771f2dc3c3f94484e",
+			  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+			},
+			{
+			  "id": "1",
+			  "message": "Thanks, Gotts",
+			  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841bfd0a9a7f8a0c487a008a0d20f26abad55bbae626e7ddaf985cf57452f27c44a1",
+			  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b62b1d9b023a5cfece03e976900bd55a25a34e896c2fe5ee13fdaeb413620ae74",
+			  "public_blind_excess": "026fd9331688e26ba0703f700d6d1c0c1626ca02389d5a1aa981cf0e77bb83d370",
+			  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+			}
+		  ],
+		  "tx": {
+			"body": {
+			  "inputs": [
 				{
-				  "id": "0",
-				  "message": null,
-				  "message_sig": null,
-				  "part_sig": null,
-				  "public_blind_excess": "020e44132261fcdc9112d1bae25ab54d9c00609353cb23143771f2dc3c3f94484e",
-				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+				  "SingleInput": {
+					"commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491",
+					"features": "Coinbase"
+				  }
 				},
 				{
-				  "id": "1",
-				  "message": "Thanks, Gotts",
-				  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841bfd0a9a7f8a0c487a008a0d20f26abad55bbae626e7ddaf985cf57452f27c44a1",
-				  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b62b1d9b023a5cfece03e976900bd55a25a34e896c2fe5ee13fdaeb413620ae74",
-				  "public_blind_excess": "026fd9331688e26ba0703f700d6d1c0c1626ca02389d5a1aa981cf0e77bb83d370",
-				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+				  "SingleInput": {
+					"commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4",
+					"features": "Coinbase"
+				  }
 				}
 			  ],
-			  "tx": {
-				"body": {
-				  "inputs": [
-					{
-					  "SingleInput": {
-						"commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491",
-						"features": "Coinbase"
-					  }
-					},
-					{
-					  "SingleInput": {
-						"commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4",
-						"features": "Coinbase"
-					  }
-					}
-				  ],
-				  "kernels": [
-					{
-					  "excess": "000000000000000000000000000000000000000000000000000000000000000000",
-					  "excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-					  "features": "Plain",
-					  "fee": "7000000",
-					  "lock_height": "0"
-					}
-				  ],
-				  "outputs": [
-					{
-					  "commit": "099af2fbafc88308fc210cf6341a443b90312f2dfb90b50cda0c7d1dc5d5a59c6e",
-					  "features": {
-						"Plain": {
-						  "spath": "9e0f681afae46a92556f7086b1e6c2146effd2c8f2c25727946b249e"
-						}
-					  },
-					  "value": 59993000000
-					},
-					{
-					  "commit": "08f1d803372a08c4f2b456efc207dc6d761ffdc3933cf6f8894a18f923614cf33d",
-					  "features": {
-						"Plain": {
-						  "spath": "e84cac3c1f54d6b4da205012eaa1a0a20af497faee5e7ea28dd159f2"
-						}
-					  },
-					  "value": 60000000000
-					}
-				  ]
+			  "kernels": [
+				{
+				  "excess": "000000000000000000000000000000000000000000000000000000000000000000",
+				  "excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				  "features": "Plain",
+				  "fee": "7000000",
+				  "lock_height": "0"
 				}
-			  },
-			  "version_info": {
-				"block_header_version": 1,
-				"orig_version": 2,
-				"version": 2
-			  },
-			  "w": "-64"
+			  ],
+			  "outputs": [
+				{
+				  "commit": "099af2fbafc88308fc210cf6341a443b90312f2dfb90b50cda0c7d1dc5d5a59c6e",
+				  "features": {
+					"Plain": {
+					  "spath": "dd1095c1ea0180f076c18bda"
+					}
+				  },
+				  "value": 59993000000
+				},
+				{
+				  "commit": "08f1d803372a08c4f2b456efc207dc6d761ffdc3933cf6f8894a18f923614cf33d",
+				  "features": {
+					"Plain": {
+					  "spath": "b7066d5482676647fb486605"
+					}
+				  },
+				  "value": 60000000000
+				}
+			  ]
 			}
+		  },
+		  "version_info": {
+			"block_header_version": 1,
+			"orig_version": 2,
+			"version": 2
+		  },
+		  "w": "-64"
 		}
+	  }
 	}
 	# "#
 	# , 5, true, false);
@@ -400,172 +400,172 @@ pub trait ForeignRpc {
 		"method": "finalize_invoice_tx",
 		"id": 1,
 		"params": [{
-			"version_info": {
-				"version": 2,
-				"orig_version": 2,
-				"block_header_version": 1
-			},
-			"num_participants": 2,
-			"id": "0436430c-2b02-624c-2032-570501212b00",
-			"tx": {
-				"body": {
-				  "inputs": [
-					{
-					  "SingleInput": {
-						"features": "Coinbase",
-						"commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491"
-					  }
-					},
-					{
-					  "SingleInput": {
-						"features": "Coinbase",
-						"commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4"
-					  }
-					}
-				  ],
-				  "outputs": [
-					{
-					  "features": {
-						"Plain": {
-						  "spath": "ff025131ff654169e576baeba558a3a43043699745a188a3ef7622ed"
-						}
-					  },
-					  "commit": "08a731abf4be6e11b29beb185ef0f0bab42e5030c7cbcf3f1479abafa0faee3d8f",
-					  "value": 60000000000
-					},
-					{
-					  "features": {
-						"Plain": {
-						  "spath": "a204b97f97f1e4a244ad04a9ba3a9add96f96d98dc7bb67bf47471a6"
-						}
-					  },
-					  "commit": "089666c8f88c6aab115a041551f37cc5f9d03e6180f8f9d2613a7f8485dcc81df5",
-					  "value": 59993000000
-					}
-				  ],
-				  "kernels": [
-					{
-					  "features": "Plain",
-					  "fee": "7000000",
-					  "lock_height": "0",
-					  "excess": "000000000000000000000000000000000000000000000000000000000000000000",
-					  "excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-					}
-				  ]
-				}
-			},
-			"amount": "60000000000",
-			"w": "64",
-			"fee": "7000000",
-			"height": "5",
-			"lock_height": "0",
-			"participant_data": [
+		  "version_info": {
+			"version": 2,
+			"orig_version": 2,
+			"block_header_version": 1
+		  },
+		  "num_participants": 2,
+		  "id": "0436430c-2b02-624c-2032-570501212b00",
+		  "tx": {
+			"body": {
+			  "inputs": [
 				{
-				  "id": "1",
-				  "public_blind_excess": "03900add00e609f21c5565fa95b09824973d2f8985119e59fcf26acb27b6133fd3",
-				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
-				  "part_sig": null,
-				  "message": null,
-				  "message_sig": null
+				  "SingleInput": {
+					"features": "Coinbase",
+					"commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491"
+				  }
 				},
 				{
-				  "id": "0",
-				  "public_blind_excess": "020e44132261fcdc9112d1bae25ab54d9c00609353cb23143771f2dc3c3f94484e",
-				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
-				  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b267c4d03effc5d6961657de79245ffe3d90637df26cbaa5a06f2be09f8550402",
-				  "message": null,
-				  "message_sig": null
+				  "SingleInput": {
+					"features": "Coinbase",
+					"commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4"
+				  }
 				}
-			]
-		}]
+			  ],
+			  "outputs": [
+				{
+				  "features": {
+					"Plain": {
+					  "spath": "ccf1733bd7014cc25dc6e233"
+					}
+				  },
+				  "commit": "08a731abf4be6e11b29beb185ef0f0bab42e5030c7cbcf3f1479abafa0faee3d8f",
+				  "value": 60000000000
+				},
+				{
+				  "features": {
+					"Plain": {
+					  "spath": "862bb1f0586dc062c7cae818"
+					}
+				  },
+				  "commit": "089666c8f88c6aab115a041551f37cc5f9d03e6180f8f9d2613a7f8485dcc81df5",
+				  "value": 59993000000
+				}
+			  ],
+			  "kernels": [
+				{
+				  "features": "Plain",
+				  "fee": "7000000",
+				  "lock_height": "0",
+				  "excess": "000000000000000000000000000000000000000000000000000000000000000000",
+				  "excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+				}
+			  ]
+			}
+		  },
+		  "amount": "60000000000",
+		  "w": "64",
+		  "fee": "7000000",
+		  "height": "5",
+		  "lock_height": "0",
+		  "participant_data": [
+			{
+			  "id": "1",
+			  "public_blind_excess": "03900add00e609f21c5565fa95b09824973d2f8985119e59fcf26acb27b6133fd3",
+			  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+			  "part_sig": null,
+			  "message": null,
+			  "message_sig": null
+			},
+			{
+			  "id": "0",
+			  "public_blind_excess": "020e44132261fcdc9112d1bae25ab54d9c00609353cb23143771f2dc3c3f94484e",
+			  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+			  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b267c4d03effc5d6961657de79245ffe3d90637df26cbaa5a06f2be09f8550402",
+			  "message": null,
+			  "message_sig": null
+			}
+		  ]
+		 }]
 	}
 	# "#
 	# ,
 	# r#"
 	{
-		"id": 1,
-		"jsonrpc": "2.0",
-		"result": {
-			"Ok": {
-			  "amount": "60000000000",
-			  "fee": "7000000",
-			  "height": "5",
-			  "id": "0436430c-2b02-624c-2032-570501212b00",
-			  "lock_height": "0",
-			  "num_participants": 2,
-			  "participant_data": [
+	  "id": 1,
+	  "jsonrpc": "2.0",
+	  "result": {
+		"Ok": {
+		  "amount": "60000000000",
+		  "fee": "7000000",
+		  "height": "5",
+		  "id": "0436430c-2b02-624c-2032-570501212b00",
+		  "lock_height": "0",
+		  "num_participants": 2,
+		  "participant_data": [
+			{
+			  "id": "1",
+			  "message": null,
+			  "message_sig": null,
+			  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b02f44f6e1a2b319a8cfb59afbf87e3cded9036e8eabd3cd3a66ff8145b685a0b",
+			  "public_blind_excess": "03900add00e609f21c5565fa95b09824973d2f8985119e59fcf26acb27b6133fd3",
+			  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+			},
+			{
+			  "id": "0",
+			  "message": null,
+			  "message_sig": null,
+			  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b267c4d03effc5d6961657de79245ffe3d90637df26cbaa5a06f2be09f8550402",
+			  "public_blind_excess": "020e44132261fcdc9112d1bae25ab54d9c00609353cb23143771f2dc3c3f94484e",
+			  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+			}
+		  ],
+		  "tx": {
+			"body": {
+			  "inputs": [
 				{
-				  "id": "1",
-				  "message": null,
-				  "message_sig": null,
-				  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b02f44f6e1a2b319a8cfb59afbf87e3cded9036e8eabd3cd3a66ff8145b685a0b",
-				  "public_blind_excess": "03900add00e609f21c5565fa95b09824973d2f8985119e59fcf26acb27b6133fd3",
-				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+				  "SingleInput": {
+					"commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491",
+					"features": "Coinbase"
+				  }
 				},
 				{
-				  "id": "0",
-				  "message": null,
-				  "message_sig": null,
-				  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b267c4d03effc5d6961657de79245ffe3d90637df26cbaa5a06f2be09f8550402",
-				  "public_blind_excess": "020e44132261fcdc9112d1bae25ab54d9c00609353cb23143771f2dc3c3f94484e",
-				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+				  "SingleInput": {
+					"commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4",
+					"features": "Coinbase"
+				  }
 				}
 			  ],
-			  "tx": {
-				"body": {
-				  "inputs": [
-					{
-					  "SingleInput": {
-						"commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491",
-						"features": "Coinbase"
-					  }
-					},
-					{
-					  "SingleInput": {
-						"commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4",
-						"features": "Coinbase"
-					  }
-					}
-				  ],
-				  "kernels": [
-					{
-					  "excess": "087e67f6adc6e5d29345d2155e190cf90822dfdd3a4fab1f3f033b44f8c1827b62",
-					  "excess_sig": "66074d25a751c4743342c90ad8ead9454daa00d9b9aed29bca321036d16c4b4d28709d7109288f03ee60d79652cde2b1c7976dc71189e72dad61b71e53be5e0d",
-					  "features": "Plain",
-					  "fee": "7000000",
-					  "lock_height": "0"
-					}
-				  ],
-				  "outputs": [
-					{
-					  "commit": "08a731abf4be6e11b29beb185ef0f0bab42e5030c7cbcf3f1479abafa0faee3d8f",
-					  "features": {
-						"Plain": {
-						  "spath": "ff025131ff654169e576baeba558a3a43043699745a188a3ef7622ed"
-						}
-					  },
-					  "value": 60000000000
-					},
-					{
-					  "commit": "089666c8f88c6aab115a041551f37cc5f9d03e6180f8f9d2613a7f8485dcc81df5",
-					  "features": {
-						"Plain": {
-						  "spath": "a204b97f97f1e4a244ad04a9ba3a9add96f96d98dc7bb67bf47471a6"
-						}
-					  },
-					  "value": 59993000000
-					}
-				  ]
+			  "kernels": [
+				{
+				  "excess": "087e67f6adc6e5d29345d2155e190cf90822dfdd3a4fab1f3f033b44f8c1827b62",
+				  "excess_sig": "66074d25a751c4743342c90ad8ead9454daa00d9b9aed29bca321036d16c4b4d28709d7109288f03ee60d79652cde2b1c7976dc71189e72dad61b71e53be5e0d",
+				  "features": "Plain",
+				  "fee": "7000000",
+				  "lock_height": "0"
 				}
-			  },
-			  "version_info": {
-				"block_header_version": 1,
-				"orig_version": 2,
-				"version": 2
-			  },
-			  "w": "64"
+			  ],
+			  "outputs": [
+				{
+				  "commit": "08a731abf4be6e11b29beb185ef0f0bab42e5030c7cbcf3f1479abafa0faee3d8f",
+				  "features": {
+					"Plain": {
+					  "spath": "ccf1733bd7014cc25dc6e233"
+					}
+				  },
+				  "value": 60000000000
+				},
+				{
+				  "commit": "089666c8f88c6aab115a041551f37cc5f9d03e6180f8f9d2613a7f8485dcc81df5",
+				  "features": {
+					"Plain": {
+					  "spath": "862bb1f0586dc062c7cae818"
+					}
+				  },
+				  "value": 59993000000
+				}
+			  ]
 			}
+		  },
+		  "version_info": {
+			"block_header_version": 1,
+			"orig_version": 2,
+			"version": 2
+		  },
+		  "w": "64"
 		}
+	  }
 	}
 	# "#
 	# , 5, false, true);

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -404,7 +404,7 @@ pub trait OwnerRpc {
 					  "commit": "08e7af2033557d22be69fbffca0cd2181ab775b1a7ae594ba01248e410c6587a78",
 					  "features": {
 						"Plain": {
-						  "spath": "0b3fbe3083c497835386fabb3b26bce280d49567e29d36fd877af1d4"
+						  "spath": "9f07ee9602c6d772d4df0f4f"
 						}
 					  },
 					  "value": 53992000000
@@ -462,9 +462,9 @@ pub trait OwnerRpc {
 		# ,
 		# r#"
 		{
-		  "id": 1,
-		  "jsonrpc": "2.0",
-		  "result": {
+			"id": 1,
+			"jsonrpc": "2.0",
+			"result": {
 			"Ok": {
 			  "amount": "6000000000",
 			  "fee": "8000000",
@@ -528,7 +528,7 @@ pub trait OwnerRpc {
 					  "commit": "08e7af2033557d22be69fbffca0cd2181ab775b1a7ae594ba01248e410c6587a78",
 					  "features": {
 						"Plain": {
-						  "spath": "0b3fbe3083c497835386fabb3b26bce280d49567e29d36fd877af1d4"
+						  "spath": "9f07ee9602c6d772d4df0f4f"
 						}
 					  },
 					  "value": 53992000000
@@ -543,7 +543,7 @@ pub trait OwnerRpc {
 			  },
 			  "w": "-64"
 			}
-		  }
+			}
 		}
 		# "#
 		# ,4, false, false, false);
@@ -578,55 +578,55 @@ pub trait OwnerRpc {
 			"id": 1,
 			"jsonrpc": "2.0",
 			"result": {
-				"Ok": {
-					"amount": "6000000000",
-					"fee": "0",
-					"height": "4",
-					"id": "0436430c-2b02-624c-2032-570501212b00",
-					"lock_height": "0",
-					"num_participants": 2,
-					"participant_data": [
-						{
-						  "id": "1",
-						  "message": "Please give me your gotts",
-						  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b9e196e487ee7865a2901d1ad0012a7bd25ddc0759fd1cca3e02e8f402dd01dd2",
-						  "part_sig": null,
-						  "public_blind_excess": "03453117c78d6d9f2885602a843856b4737b3e0838b28b3f861c5082fbfa428c36",
-						  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
-						}
-					],
-					"tx": {
-						"body": {
-							"inputs": [],
-							"kernels": [
-								{
-									"excess": "000000000000000000000000000000000000000000000000000000000000000000",
-									"excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-									"features": "Plain",
-									"fee": "0",
-									"lock_height": "0"
-								}
-							],
-							"outputs": [
-								{
-								  "commit": "08e7af2033557d22be69fbffca0cd2181ab775b1a7ae594ba01248e410c6587a78",
-								  "features": {
-									"Plain": {
-									  "spath": "0b3fbe3083c497835386fabb3b26bce280d49567e29d36fd877af1d4"
-									}
-								  },
-								  "value": 6000000000
-								}
-							]
-						}
-					},
-					"version_info": {
-						"orig_version": 2,
-						"version": 2,
-						"block_header_version": 1
-					},
-					"w": "64"
+			"Ok": {
+			  "amount": "6000000000",
+			  "fee": "0",
+			  "height": "4",
+			  "id": "0436430c-2b02-624c-2032-570501212b00",
+			  "lock_height": "0",
+			  "num_participants": 2,
+			  "participant_data": [
+				{
+				  "id": "1",
+				  "message": "Please give me your gotts",
+				  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b9e196e487ee7865a2901d1ad0012a7bd25ddc0759fd1cca3e02e8f402dd01dd2",
+				  "part_sig": null,
+				  "public_blind_excess": "03453117c78d6d9f2885602a843856b4737b3e0838b28b3f861c5082fbfa428c36",
+				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
 				}
+			  ],
+			  "tx": {
+				"body": {
+				  "inputs": [],
+				  "kernels": [
+					{
+					  "excess": "000000000000000000000000000000000000000000000000000000000000000000",
+					  "excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					  "features": "Plain",
+					  "fee": "0",
+					  "lock_height": "0"
+					}
+				  ],
+				  "outputs": [
+					{
+					  "commit": "08e7af2033557d22be69fbffca0cd2181ab775b1a7ae594ba01248e410c6587a78",
+					  "features": {
+						"Plain": {
+						  "spath": "9f07ee9602c6d772d4df0f4f"
+						}
+					  },
+					  "value": 6000000000
+					}
+				  ]
+				}
+			  },
+			  "version_info": {
+				"block_header_version": 1,
+				"orig_version": 2,
+				"version": 2
+			  },
+			  "w": "64"
+			}
 			}
 		}
 		# "#
@@ -647,53 +647,53 @@ pub trait OwnerRpc {
 			"method": "process_invoice_tx",
 			"params": [
 				{
-					"amount": "6000000000",
-					"w": "64",
-					"fee": "0",
-					"height": "4",
-					"id": "0436430c-2b02-624c-2032-570501212b00",
-					"lock_height": "0",
-					"num_participants": 2,
-					"participant_data": [
-						{
-						  "id": "1",
-						  "message": "Please give me your gotts",
-						  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b5e2dca8b19c930f5f2db2b83163172610cf2b4038e8add5b1f471680e7db55d0",
-						  "part_sig": null,
-						  "public_blind_excess": "03af68dd2d26dfc9ade85441e8b41c49b6160423f3b0ca820a4703fa9b6a7b64cd",
-						  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
-						}
-					],
-					"tx": {
-						"body": {
-							"inputs": [],
-							"kernels": [
-								{
-									"excess": "000000000000000000000000000000000000000000000000000000000000000000",
-									"excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-									"features": "Plain",
-									"fee": "0",
-									"lock_height": "0"
-								}
-							],
-							"outputs": [
-								{
-								  "commit": "08e7af2033557d22be69fbffca0cd2181ab775b1a7ae594ba01248e410c6587a78",
-								  "features": {
-									"Plain": {
-									  "spath": "0b3fbe3083c497835386fabb3b26bce280d49567e29d36fd877af1d4"
-									}
-								  },
-								  "value": 6000000000
-								}
-							]
-						}
-					},
-					"version_info": {
-						"orig_version": 2,
-						"version": 2,
-						"block_header_version": 1
+				  "amount": "6000000000",
+				  "fee": "0",
+				  "height": "4",
+				  "id": "0436430c-2b02-624c-2032-570501212b00",
+				  "lock_height": "0",
+				  "num_participants": 2,
+				  "participant_data": [
+					{
+					  "id": "1",
+					  "message": "Please give me your gotts",
+					  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b9e196e487ee7865a2901d1ad0012a7bd25ddc0759fd1cca3e02e8f402dd01dd2",
+					  "part_sig": null,
+					  "public_blind_excess": "03453117c78d6d9f2885602a843856b4737b3e0838b28b3f861c5082fbfa428c36",
+					  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
 					}
+				  ],
+				  "tx": {
+					"body": {
+					  "inputs": [],
+					  "kernels": [
+						{
+						  "excess": "000000000000000000000000000000000000000000000000000000000000000000",
+						  "excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+						  "features": "Plain",
+						  "fee": "0",
+						  "lock_height": "0"
+						}
+					  ],
+					  "outputs": [
+						{
+						  "commit": "08e7af2033557d22be69fbffca0cd2181ab775b1a7ae594ba01248e410c6587a78",
+						  "features": {
+							"Plain": {
+							  "spath": "9f07ee9602c6d772d4df0f4f"
+							}
+						  },
+						  "value": 6000000000
+						}
+					  ]
+					}
+				  },
+				  "version_info": {
+					"block_header_version": 1,
+					"orig_version": 2,
+					"version": 2
+				  },
+				  "w": "64"
 				},
 				{
 					"src_acct_name": null,
@@ -713,9 +713,9 @@ pub trait OwnerRpc {
 		# ,
 		# r#"
 		{
-		"id": 1,
-		"jsonrpc": "2.0",
-		"result": {
+			"id": 1,
+			"jsonrpc": "2.0",
+			"result": {
 			"Ok": {
 			  "amount": "6000000000",
 			  "fee": "8000000",
@@ -727,16 +727,16 @@ pub trait OwnerRpc {
 				{
 				  "id": "1",
 				  "message": "Please give me your gotts",
-				  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b5e2dca8b19c930f5f2db2b83163172610cf2b4038e8add5b1f471680e7db55d0",
+				  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b9e196e487ee7865a2901d1ad0012a7bd25ddc0759fd1cca3e02e8f402dd01dd2",
 				  "part_sig": null,
-				  "public_blind_excess": "03af68dd2d26dfc9ade85441e8b41c49b6160423f3b0ca820a4703fa9b6a7b64cd",
+				  "public_blind_excess": "03453117c78d6d9f2885602a843856b4737b3e0838b28b3f861c5082fbfa428c36",
 				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
 				},
 				{
 				  "id": "0",
 				  "message": "Ok, here are your gotts",
 				  "message_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841bfc5a7e9c2fb684ffb21618abccff2f78f9355ab93213defa3a9566a561797dd6",
-				  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841bc0f1a8b847af95c4aae9a50ec9ef396a79bae307a17dd1c29a85fd1a0454763e",
+				  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b1292445b05de4fbb4e1f4136f39884f084e2cbd15a80c14a25db436992b5999b",
 				  "public_blind_excess": "0306ba3e5c535f6fc26fea5b7a37ab21c99b7b31c86ab922e0e175b6998dcd36c0",
 				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
 				}
@@ -765,7 +765,7 @@ pub trait OwnerRpc {
 					  "commit": "08e1e17735ff0e4217bdd253bc0e9933a0c01bdf1dd08dccf6cf2e36b776ebae9d",
 					  "features": {
 						"Plain": {
-						  "spath": "a49a6ddeb5054ff64a3837ff8a68e8a4f475c71c51b7acc6d44a5014"
+						  "spath": "8b2d48dfec02d9d54c65886f"
 						}
 					  },
 					  "value": 53992000000
@@ -774,7 +774,7 @@ pub trait OwnerRpc {
 					  "commit": "08e7af2033557d22be69fbffca0cd2181ab775b1a7ae594ba01248e410c6587a78",
 					  "features": {
 						"Plain": {
-						  "spath": "0b3fbe3083c497835386fabb3b26bce280d49567e29d36fd877af1d4"
+						  "spath": "9f07ee9602c6d772d4df0f4f"
 						}
 					  },
 					  "value": 6000000000
@@ -789,7 +789,7 @@ pub trait OwnerRpc {
 			  },
 			  "w": "64"
 			}
-		}
+			}
 	}
 	# "#
 	# ,4, false, false, false);
@@ -937,7 +937,7 @@ pub trait OwnerRpc {
 				{
 				  "features": {
 					"Plain": {
-					  "spath": "c7392a2915c120a3072571a19a7e73ae71ceee117c5c8615b1aeb44a"
+					  "spath": "3bbf1cb8082ce224e443f714"
 					}
 				  },
 				  "commit": "09e66a240425be5d6e8873c78f87c1489cb77736216a8fb0639962d7e3b4111b9e",
@@ -946,7 +946,7 @@ pub trait OwnerRpc {
 				{
 				  "features": {
 					"Plain": {
-					  "spath": "9e0f681afae46a92556f7086b1e6c2146effd2c8f2c25727946b249e"
+					  "spath": "dd1095c1ea0180f076c18bda"
 					}
 				  },
 				  "commit": "099af2fbafc88308fc210cf6341a443b90312f2dfb90b50cda0c7d1dc5d5a59c6e",
@@ -994,88 +994,88 @@ pub trait OwnerRpc {
 	# ,
 	# r#"
 	{
-		"jsonrpc": "2.0",
 		"id": 1,
+		"jsonrpc": "2.0",
 		"result": {
 		"Ok": {
-			  "amount": "60000000000",
-			  "fee": "7000000",
-			  "height": "5",
-			  "id": "0436430c-2b02-624c-2032-570501212b00",
-			  "lock_height": "0",
-			  "num_participants": 2,
-			  "participant_data": [
+		  "amount": "60000000000",
+		  "fee": "7000000",
+		  "height": "5",
+		  "id": "0436430c-2b02-624c-2032-570501212b00",
+		  "lock_height": "0",
+		  "num_participants": 2,
+		  "participant_data": [
+			{
+			  "id": "0",
+			  "message": null,
+			  "message_sig": null,
+			  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b267c4d03effc5d6961657de79245ffe3d90637df26cbaa5a06f2be09f8550402",
+			  "public_blind_excess": "020e44132261fcdc9112d1bae25ab54d9c00609353cb23143771f2dc3c3f94484e",
+			  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+			},
+			{
+			  "id": "1",
+			  "message": null,
+			  "message_sig": null,
+			  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b02f44f6e1a2b319a8cfb59afbf87e3cded9036e8eabd3cd3a66ff8145b685a0b",
+			  "public_blind_excess": "03900add00e609f21c5565fa95b09824973d2f8985119e59fcf26acb27b6133fd3",
+			  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+			}
+		  ],
+		  "tx": {
+			"body": {
+			  "inputs": [
 				{
-				  "id": "0",
-				  "message": null,
-				  "message_sig": null,
-				  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b267c4d03effc5d6961657de79245ffe3d90637df26cbaa5a06f2be09f8550402",
-				  "public_blind_excess": "020e44132261fcdc9112d1bae25ab54d9c00609353cb23143771f2dc3c3f94484e",
-				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+				  "SingleInput": {
+					"commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491",
+					"features": "Coinbase"
+				  }
 				},
 				{
-				  "id": "1",
-				  "message": null,
-				  "message_sig": null,
-				  "part_sig": "8f07ddd5e9f5179cff19486034181ed76505baaad53e5d994064127b56c5841b02f44f6e1a2b319a8cfb59afbf87e3cded9036e8eabd3cd3a66ff8145b685a0b",
-				  "public_blind_excess": "03900add00e609f21c5565fa95b09824973d2f8985119e59fcf26acb27b6133fd3",
-				  "public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
+				  "SingleInput": {
+					"commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4",
+					"features": "Coinbase"
+				  }
 				}
 			  ],
-			  "tx": {
-				"body": {
-				  "inputs": [
-					{
-					  "SingleInput": {
-						"commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491",
-						"features": "Coinbase"
-					  }
-					},
-					{
-					  "SingleInput": {
-						"commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4",
-						"features": "Coinbase"
-					  }
-					}
-				  ],
-				  "kernels": [
-					{
-					  "excess": "087e67f6adc6e5d29345d2155e190cf90822dfdd3a4fab1f3f033b44f8c1827b62",
-					  "excess_sig": "66074d25a751c4743342c90ad8ead9454daa00d9b9aed29bca321036d16c4b4d28709d7109288f03ee60d79652cde2b1c7976dc71189e72dad61b71e53be5e0d",
-					  "features": "Plain",
-					  "fee": "7000000",
-					  "lock_height": "0"
-					}
-				  ],
-				  "outputs": [
-					{
-					  "commit": "09e66a240425be5d6e8873c78f87c1489cb77736216a8fb0639962d7e3b4111b9e",
-					  "features": {
-						"Plain": {
-						  "spath": "c7392a2915c120a3072571a19a7e73ae71ceee117c5c8615b1aeb44a"
-						}
-					  },
-					  "value": 60000000000
-					},
-					{
-					  "commit": "099af2fbafc88308fc210cf6341a443b90312f2dfb90b50cda0c7d1dc5d5a59c6e",
-					  "features": {
-						"Plain": {
-						  "spath": "9e0f681afae46a92556f7086b1e6c2146effd2c8f2c25727946b249e"
-						}
-					  },
-					  "value": 59993000000
-					}
-				  ]
+			  "kernels": [
+				{
+				  "excess": "087e67f6adc6e5d29345d2155e190cf90822dfdd3a4fab1f3f033b44f8c1827b62",
+				  "excess_sig": "66074d25a751c4743342c90ad8ead9454daa00d9b9aed29bca321036d16c4b4d28709d7109288f03ee60d79652cde2b1c7976dc71189e72dad61b71e53be5e0d",
+				  "features": "Plain",
+				  "fee": "7000000",
+				  "lock_height": "0"
 				}
-			  },
-			  "version_info": {
-				"block_header_version": 1,
-				"orig_version": 2,
-				"version": 2
-			  },
-			  "w": "-64"
+			  ],
+			  "outputs": [
+				{
+				  "commit": "09e66a240425be5d6e8873c78f87c1489cb77736216a8fb0639962d7e3b4111b9e",
+				  "features": {
+					"Plain": {
+					  "spath": "3bbf1cb8082ce224e443f714"
+					}
+				  },
+				  "value": 60000000000
+				},
+				{
+				  "commit": "099af2fbafc88308fc210cf6341a443b90312f2dfb90b50cda0c7d1dc5d5a59c6e",
+				  "features": {
+					"Plain": {
+					  "spath": "dd1095c1ea0180f076c18bda"
+					}
+				  },
+				  "value": 59993000000
+				}
+			  ]
 			}
+		  },
+		  "version_info": {
+			"block_header_version": 1,
+			"orig_version": 2,
+			"version": 2
+		  },
+		  "w": "-64"
+		}
 		}
 	}
 	# "#
@@ -1245,57 +1245,57 @@ pub trait OwnerRpc {
 	# ,
 	# r#"
 	{
-		"jsonrpc": "2.0",
-		"id": 1,
-		"result": {
-			"Ok": {
-			  "body": {
-				"inputs": [
-				  {
-					"SingleInput": {
-					  "commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491",
-					  "features": "Coinbase"
-					}
-				  },
-				  {
-					"SingleInput": {
-					  "commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4",
-					  "features": "Coinbase"
-					}
-				  }
-				],
-				"kernels": [
-				  {
-					"excess": "000000000000000000000000000000000000000000000000000000000000000000",
-					"excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-					"features": "Plain",
-					"fee": "7000000",
-					"lock_height": "0"
-				  }
-				],
-				"outputs": [
-				  {
-					"commit": "09e66a240425be5d6e8873c78f87c1489cb77736216a8fb0639962d7e3b4111b9e",
-					"features": {
-					  "Plain": {
-						"spath": "c7392a2915c120a3072571a19a7e73ae71ceee117c5c8615b1aeb44a"
-					  }
-					},
-					"value": 60000000000
-				  },
-				  {
-					"commit": "099af2fbafc88308fc210cf6341a443b90312f2dfb90b50cda0c7d1dc5d5a59c6e",
-					"features": {
-					  "Plain": {
-						"spath": "9e0f681afae46a92556f7086b1e6c2146effd2c8f2c25727946b249e"
-					  }
-					},
-					"value": 59993000000
-				  }
-				]
+	  "id": 1,
+	  "jsonrpc": "2.0",
+	  "result": {
+		"Ok": {
+		  "body": {
+			"inputs": [
+			  {
+				"SingleInput": {
+				  "commit": "09eae1a4ac785f845b33d2689d3a48df7c158e602564d23d81078ecd5b6385b491",
+				  "features": "Coinbase"
+				}
+			  },
+			  {
+				"SingleInput": {
+				  "commit": "09a75b07e6b329e5a98be34e88d7bec3062fdddc2044a1b9efe9accec9858571c4",
+				  "features": "Coinbase"
+				}
 			  }
-			}
+			],
+			"kernels": [
+			  {
+				"excess": "000000000000000000000000000000000000000000000000000000000000000000",
+				"excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				"features": "Plain",
+				"fee": "7000000",
+				"lock_height": "0"
+			  }
+			],
+			"outputs": [
+			  {
+				"commit": "09e66a240425be5d6e8873c78f87c1489cb77736216a8fb0639962d7e3b4111b9e",
+				"features": {
+				  "Plain": {
+					"spath": "3bbf1cb8082ce224e443f714"
+				  }
+				},
+				"value": 60000000000
+			  },
+			  {
+				"commit": "099af2fbafc88308fc210cf6341a443b90312f2dfb90b50cda0c7d1dc5d5a59c6e",
+				"features": {
+				  "Plain": {
+					"spath": "dd1095c1ea0180f076c18bda"
+				  }
+				},
+				"value": 59993000000
+			  }
+			]
+		  }
 		}
+	  }
 	}
 	# "#
 	# , 5, true, true, false);

--- a/controller/tests/check.rs
+++ b/controller/tests/check.rs
@@ -511,7 +511,9 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 15);
 		assert_eq!(info.amount_currently_spendable, base_amount * 120);
+		api.create_account_path("account_1")?;
 		api.set_active_account("account_1")?;
+		api.check_repair(true, 0, None)?;
 		let info = wallet_info!(wallet8.clone())?;
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 3);
@@ -547,6 +549,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		assert_eq!(info.amount_currently_spendable, base_amount * 21);
 
 		api.set_active_account("default")?;
+		api.check_repair(true, 0, None)?;
 		let info = wallet_info!(wallet9.clone())?;
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 15);
@@ -558,14 +561,16 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// 7) Ensure check_repair creates missing accounts
 	wallet::controller::owner_single_use(wallet10.clone(), |api| {
-		api.check_repair(true, 0, None)?;
+		api.create_account_path("account_1")?;
 		api.set_active_account("account_1")?;
+		api.check_repair(true, 0, None)?;
 		let info = wallet_info!(wallet10.clone())?;
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 6);
 		assert_eq!(info.amount_currently_spendable, base_amount * 21);
 
 		api.set_active_account("default")?;
+		api.check_repair(true, 0, None)?;
 		let info = wallet_info!(wallet10.clone())?;
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 15);

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -69,8 +69,13 @@ where
 		if !is_initator { Some(slate.w) } else { None },
 		use_test_rng,
 	)?;
+	let rewind_hash_key_id = wallet.parent_key_id();
 	let keychain = wallet.keychain();
-	let blinding = slate.add_transaction_elements(keychain, &ProofBuilder::new(keychain), elems)?;
+	let blinding = slate.add_transaction_elements(
+		keychain,
+		&ProofBuilder::new(keychain, &rewind_hash_key_id),
+		elems,
+	)?;
 
 	slate.fee = fee;
 	let mut sum_of_w: i64 = inputs.iter().fold(0i64, |acc, x| acc.saturating_add(x.w));
@@ -208,6 +213,7 @@ where
 	// Create a potential output for this transaction
 	let key_id = keys::next_available_key(wallet).unwrap();
 	let keychain = wallet.keychain().clone();
+	let rewind_hash_key_id = wallet.parent_key_id();
 	let key_id_inner = key_id.clone();
 	let amount = slate.amount;
 	let w = slate.w;
@@ -222,7 +228,7 @@ where
 	let blinding = match recipient_address {
 		Some(addr) => slate.add_transaction_elements(
 			&keychain,
-			&ProofBuilder::new(&keychain),
+			&ProofBuilder::new(&keychain, &rewind_hash_key_id),
 			vec![build::non_interactive_output(
 				amount,
 				Some(w),
@@ -232,7 +238,7 @@ where
 		)?,
 		None => slate.add_transaction_elements(
 			&keychain,
-			&ProofBuilder::new(&keychain),
+			&ProofBuilder::new(&keychain, &rewind_hash_key_id),
 			vec![build::output(amount, Some(w), key_id.clone())],
 		)?,
 	};

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -449,7 +449,7 @@ where
 #[cfg(test)]
 mod test {
 	use crate::gotts_core::libtx::{build, ProofBuilder};
-	use crate::gotts_keychain::{ExtKeychain, ExtKeychainPath, Keychain};
+	use crate::gotts_keychain::{ExtKeychain, ExtKeychainPath, Identifier, Keychain};
 	use rand::{thread_rng, Rng};
 
 	#[test]
@@ -457,7 +457,7 @@ mod test {
 	// based on the public key and amount begin spent
 	fn output_commitment_equals_input_commitment_on_spend() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let w: i64 = thread_rng().gen();
 

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -747,7 +747,7 @@ where
 	let keychain = wallet.keychain();
 	let (out, kern) = reward::output(
 		keychain,
-		&ProofBuilder::new(keychain),
+		&ProofBuilder::new(keychain, &parent_key_id),
 		&key_id,
 		block_fees.fees,
 		test_mode,

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -451,7 +451,17 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
-		let arg_vec = vec!["gotts-wallet", "-p", "password", "check", "-d", "-i", "0"];
+		let arg_vec = vec![
+			"gotts-wallet",
+			"-p",
+			"password",
+			"-a",
+			"mining",
+			"check",
+			"-d",
+			"-i",
+			"0",
+		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
 		// Another file exchange, cancel this time

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -21,12 +21,12 @@ toml = "0.4"
 dirs = "1.0.3"
 
 # For Release
-gotts_core = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
-gotts_keychain = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
-gotts_chain = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
-gotts_util = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
-gotts_api = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
-gotts_store = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
+#gotts_core = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
+#gotts_keychain = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
+#gotts_chain = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
+#gotts_util = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
+#gotts_api = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
+#gotts_store = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
 
 # For beta release
 #gotts_core = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5-beta.1" }
@@ -37,12 +37,12 @@ gotts_store = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5" }
 #gotts_store = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5-beta.1" }
 
 # For bleeding edge
-#gotts_core = { git = "https://github.com/gottstech/gotts", rev = "7d82c78" }
-#gotts_keychain = { git = "https://github.com/gottstech/gotts", rev = "7d82c78" }
-#gotts_chain = { git = "https://github.com/gottstech/gotts", rev = "7d82c78" }
-#gotts_util = { git = "https://github.com/gottstech/gotts", rev = "7d82c78" }
-#gotts_api = { git = "https://github.com/gottstech/gotts", rev = "7d82c78" }
-#gotts_store = { git = "https://github.com/gottstech/gotts", rev = "7d82c78" }
+gotts_core = { git = "https://github.com/gottstech/gotts", rev = "1987486" }
+gotts_keychain = { git = "https://github.com/gottstech/gotts", rev = "1987486" }
+gotts_chain = { git = "https://github.com/gottstech/gotts", rev = "1987486" }
+gotts_util = { git = "https://github.com/gottstech/gotts", rev = "1987486" }
+gotts_api = { git = "https://github.com/gottstech/gotts", rev = "1987486" }
+gotts_store = { git = "https://github.com/gottstech/gotts", rev = "1987486" }
 
 # For local testing
 #gotts_core = { path = "../../gotts/core"}


### PR DESCRIPTION
Corresponding modifications in wallet for node PR https://github.com/gottstech/gotts/pull/37.

Refactoring the `PathMessage` structure to the shorter format:
```Rust
pub struct PathMessage {
	/// The random 'w' of Pedersen commitment `r*G + w*H`
	pub w: i64,
	/// The last path index of the key identifier
	pub key_id_last_path: u32,
}
```
