### PR TITLE
refactoring the wallet address command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,18 +627,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "gotts_api"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=769498d#769498db186ac2c27153a035b3b78516cb804bfa"
+source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "gotts_chain"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=769498d#769498db186ac2c27153a035b3b78516cb804bfa"
+source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -668,10 +668,10 @@ dependencies = [
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "gotts_core"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=769498d#769498db186ac2c27153a035b3b78516cb804bfa"
+source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
 dependencies = [
  "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -694,8 +694,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "gotts_keychain"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=769498d#769498db186ac2c27153a035b3b78516cb804bfa"
+source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -720,7 +720,7 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,16 +739,16 @@ dependencies = [
 [[package]]
 name = "gotts_p2p"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=769498d#769498db186ac2c27153a035b3b78516cb804bfa"
+source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -761,16 +761,16 @@ dependencies = [
 [[package]]
 name = "gotts_pool"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=769498d#769498db186ac2c27153a035b3b78516cb804bfa"
+source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -797,15 +797,15 @@ dependencies = [
 [[package]]
 name = "gotts_store"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=769498d#769498db186ac2c27153a035b3b78516cb804bfa"
+source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "gotts_util"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=769498d#769498db186ac2c27153a035b3b78516cb804bfa"
+source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -977,12 +977,12 @@ version = "0.0.5"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)",
+ "gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3002,15 +3002,15 @@ dependencies = [
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)" = "<none>"
-"checksum gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)" = "<none>"
-"checksum gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)" = "<none>"
-"checksum gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)" = "<none>"
-"checksum gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)" = "<none>"
-"checksum gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)" = "<none>"
+"checksum gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
+"checksum gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
+"checksum gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
+"checksum gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
+"checksum gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
+"checksum gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
 "checksum gotts_secp256k1zkp 0.7.10 (git+https://github.com/gottstech/rust-secp256k1-zkp?rev=51798f2)" = "<none>"
-"checksum gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)" = "<none>"
-"checksum gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=769498d)" = "<none>"
+"checksum gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
+"checksum gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,18 +627,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "gotts_api"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
+source = "git+https://github.com/gottstech/gotts?rev=1d61c14#1d61c142defd97ff40c52e5c4e7584511fa544ca"
 dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "gotts_chain"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
+source = "git+https://github.com/gottstech/gotts?rev=1d61c14#1d61c142defd97ff40c52e5c4e7584511fa544ca"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -668,10 +668,10 @@ dependencies = [
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "gotts_core"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
+source = "git+https://github.com/gottstech/gotts?rev=1d61c14#1d61c142defd97ff40c52e5c4e7584511fa544ca"
 dependencies = [
  "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -694,8 +694,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "gotts_keychain"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
+source = "git+https://github.com/gottstech/gotts?rev=1d61c14#1d61c142defd97ff40c52e5c4e7584511fa544ca"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -720,7 +720,7 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,16 +739,16 @@ dependencies = [
 [[package]]
 name = "gotts_p2p"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
+source = "git+https://github.com/gottstech/gotts?rev=1d61c14#1d61c142defd97ff40c52e5c4e7584511fa544ca"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -761,16 +761,16 @@ dependencies = [
 [[package]]
 name = "gotts_pool"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
+source = "git+https://github.com/gottstech/gotts?rev=1d61c14#1d61c142defd97ff40c52e5c4e7584511fa544ca"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -797,15 +797,15 @@ dependencies = [
 [[package]]
 name = "gotts_store"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
+source = "git+https://github.com/gottstech/gotts?rev=1d61c14#1d61c142defd97ff40c52e5c4e7584511fa544ca"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "gotts_util"
 version = "0.0.5"
-source = "git+https://github.com/gottstech/gotts?rev=afae264#afae26433645e1ba9b0c3018482c0f3ae5230f11"
+source = "git+https://github.com/gottstech/gotts?rev=1d61c14#1d61c142defd97ff40c52e5c4e7584511fa544ca"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -977,12 +977,12 @@ version = "0.0.5"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
- "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)",
+ "gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
+ "gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3002,15 +3002,15 @@ dependencies = [
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
-"checksum gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
-"checksum gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
-"checksum gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
-"checksum gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
-"checksum gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
+"checksum gotts_api 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)" = "<none>"
+"checksum gotts_chain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)" = "<none>"
+"checksum gotts_core 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)" = "<none>"
+"checksum gotts_keychain 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)" = "<none>"
+"checksum gotts_p2p 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)" = "<none>"
+"checksum gotts_pool 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)" = "<none>"
 "checksum gotts_secp256k1zkp 0.7.10 (git+https://github.com/gottstech/rust-secp256k1-zkp?rev=51798f2)" = "<none>"
-"checksum gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
-"checksum gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=afae264)" = "<none>"
+"checksum gotts_store 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)" = "<none>"
+"checksum gotts_util 0.0.5 (git+https://github.com/gottstech/gotts?rev=1d61c14)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -547,7 +547,7 @@ pub trait OwnerRpc {
 						  "locker": {
 							"p2pkh": "cef5ad3c9482d1e831ceacadbd53469198f33f10b3822cfef77f33a3dc9b9dd8",
 							"pub_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
-							"spath": "b02fd2272eeaaff83e7928d6"
+							"spath": "b02fd2272eeaaff82326be57"
 						  }
 						}
 					  },

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -78,7 +78,7 @@ pub trait OwnerRpc {
 	# r#"
 	{
 		"jsonrpc": "2.0",
-		"method": "create_account_path",
+		"method": "create_account",
 		"params": ["account1"],
 		"id": 1
 	}
@@ -96,7 +96,37 @@ pub trait OwnerRpc {
 	# ,4, false, false, false);
 	```
 	 */
-	fn create_account_path(&self, label: &String) -> Result<Identifier, ErrorKind>;
+	fn create_account(&self, label: &String) -> Result<Identifier, ErrorKind>;
+
+	/**
+	Networked version of [Owner::create_account_path](struct.Owner.html#method.create_account_path).
+
+	# Json rpc example
+
+	```
+	# gotts_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "create_account_path",
+		"params": ["account1", "0200000000000000010000000000000000"],
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": null
+		},
+		"id": 1
+	}
+	# "#
+	# ,4, false, false, false);
+	```
+	 */
+	fn create_account_path(&self, label: &String, path: &Identifier) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::set_active_account](struct.Owner.html#method.set_active_account).
@@ -1497,8 +1527,12 @@ where
 		Owner::accounts(self).map_err(|e| e.kind())
 	}
 
-	fn create_account_path(&self, label: &String) -> Result<Identifier, ErrorKind> {
-		Owner::create_account_path(self, label).map_err(|e| e.kind())
+	fn create_account(&self, label: &String) -> Result<Identifier, ErrorKind> {
+		Owner::create_account(self, label).map_err(|e| e.kind())
+	}
+
+	fn create_account_path(&self, label: &String, path: &Identifier) -> Result<(), ErrorKind> {
+		Owner::create_account_path(self, label, path).map_err(|e| e.kind())
 	}
 
 	fn set_active_account(&self, label: &String) -> Result<(), ErrorKind> {

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -116,21 +116,18 @@ fn comments() -> HashMap<String, String> {
 	retval.insert(
 		"keybase_notify_ttl".to_string(),
 		"
+#The Key ID last path for Gotts receiving address. Choose any value within [0, 2^31 - 1].
+#Default for random value.
+#The complete path will be the current wallet account extending this last path value:
+#i.e. Path = \"m/p1/p2/recipient_keypath\" or \"m/p1/p2/random\",
+#and the \"m/p1/p2\" depends on the current active wallet account.
+#To use a fixed Gotts receiving address, uncomment it and set it as your preferred value.
+#recipient_keypath = 0
+
 #The exploding lifetime for keybase notification on coins received.
 #Unit: Minute. Default value 1440 minutes for one day.
 #Refer to https://keybase.io/blog/keybase-exploding-messages for detail.
 #To disable this notification, set it as 0.
-"
-		.to_string(),
-	);
-	retval.insert(
-		"recipient_keypath".to_string(),
-		"
-#Recipient key path. Choose any value within [0, 2^31 - 1]. 0 as default.
-#Considering the address length, we only open the 'd3' of the path to be configurable by user,
-# - d0,d1 are fixed as u32::max, no matter what is the parent_key_id.
-# - d2 are fixed as 0 and should not be changed for recipient key.
-# i.e. The path = ExtKeychainPath::new(4, u32::max, u32::max, 0, d3).
 "
 		.to_string(),
 	);

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -78,7 +78,7 @@ impl Default for WalletConfig {
 			tls_certificate_key: None,
 			dark_background_color_scheme: Some(true),
 			keybase_notify_ttl: Some(1440),
-			recipient_keypath: Some(0),
+			recipient_keypath: None,
 		}
 	}
 }

--- a/controller/tests/accounts.rs
+++ b/controller/tests/accounts.rs
@@ -84,21 +84,21 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		let new_path = api.create_account_path("account1").unwrap();
+		let new_path = api.create_account("account1").unwrap();
 		assert_eq!(new_path, ExtKeychain::derive_key_id(2, 1, 0, 0, 0));
-		let new_path = api.create_account_path("account2").unwrap();
+		let new_path = api.create_account("account2").unwrap();
 		assert_eq!(new_path, ExtKeychain::derive_key_id(2, 2, 0, 0, 0));
-		let new_path = api.create_account_path("account3").unwrap();
+		let new_path = api.create_account("account3").unwrap();
 		assert_eq!(new_path, ExtKeychain::derive_key_id(2, 3, 0, 0, 0));
 		// trying to add same label again should fail
-		let res = api.create_account_path("account1");
+		let res = api.create_account("account1");
 		assert!(res.is_err());
 		Ok(())
 	})?;
 
 	// add account to wallet 2
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		let new_path = api.create_account_path("listener_account").unwrap();
+		let new_path = api.create_account("listener_account").unwrap();
 		assert_eq!(new_path, ExtKeychain::derive_key_id(2, 1, 0, 0, 0));
 		Ok(())
 	})?;

--- a/controller/tests/check.rs
+++ b/controller/tests/check.rs
@@ -98,16 +98,16 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.create_account_path("account_1")?;
-		api.create_account_path("account_2")?;
-		api.create_account_path("account_3")?;
+		api.create_account("account_1")?;
+		api.create_account("account_2")?;
+		api.create_account("account_3")?;
 		api.set_active_account("account_1")?;
 		Ok(())
 	})?;
 
 	// add account to wallet 2
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.create_account_path("account_1")?;
+		api.create_account("account_1")?;
 		api.set_active_account("account_1")?;
 		Ok(())
 	})?;
@@ -478,7 +478,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// mix it up a bit
 	wallet::controller::owner_single_use(wallet7.clone(), |api| {
-		api.create_account_path("account_1")?;
+		api.create_account("account_1")?;
 		api.set_active_account("account_1")?;
 		Ok(())
 	})?;
@@ -511,7 +511,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		let outputs = api.retrieve_outputs(true, false, None)?.1;
 		assert_eq!(outputs.len(), 15);
 		assert_eq!(info.amount_currently_spendable, base_amount * 120);
-		api.create_account_path("account_1")?;
+		api.create_account("account_1")?;
 		api.set_active_account("account_1")?;
 		api.check_repair(true, 0, None)?;
 		let info = wallet_info!(wallet8.clone())?;
@@ -526,7 +526,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	// to now into 2 accounts
 
 	wallet::controller::owner_single_use(wallet9.clone(), |api| {
-		api.create_account_path("account_1")?;
+		api.create_account("account_1")?;
 		api.set_active_account("account_1")?;
 		Ok(())
 	})?;
@@ -561,7 +561,7 @@ fn two_wallets_one_seed_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// 7) Ensure check_repair creates missing accounts
 	wallet::controller::owner_single_use(wallet10.clone(), |api| {
-		api.create_account_path("account_1")?;
+		api.create_account("account_1")?;
 		api.set_active_account("account_1")?;
 		api.check_repair(true, 0, None)?;
 		let info = wallet_info!(wallet10.clone())?;

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -76,15 +76,15 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.create_account_path("mining")?;
-		api.create_account_path("listener")?;
+		api.create_account("mining")?;
+		api.create_account("listener")?;
 		Ok(())
 	})?;
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.create_account_path("account1")?;
-		api.create_account_path("account2")?;
+		api.create_account("account1")?;
+		api.create_account("account2")?;
 		Ok(())
 	})?;
 

--- a/controller/tests/invoice.rs
+++ b/controller/tests/invoice.rs
@@ -80,8 +80,8 @@ fn invoice_tx_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 		// add some accounts
 		wallet::controller::owner_single_use(wallet1.clone(), |api| {
-			api.create_account_path("mining")?;
-			api.create_account_path("listener")?;
+			api.create_account("mining")?;
+			api.create_account("listener")?;
 			Ok(())
 		})?;
 

--- a/controller/tests/repost.rs
+++ b/controller/tests/repost.rs
@@ -73,15 +73,15 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.create_account_path("mining")?;
-		api.create_account_path("listener")?;
+		api.create_account("mining")?;
+		api.create_account("listener")?;
 		Ok(())
 	})?;
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.create_account_path("account1")?;
-		api.create_account_path("account2")?;
+		api.create_account("account1")?;
+		api.create_account("account2")?;
 		Ok(())
 	})?;
 

--- a/controller/tests/restore.rs
+++ b/controller/tests/restore.rs
@@ -76,14 +76,14 @@ fn restore_wallet(base_dir: &str, wallet_dir: &str) -> Result<(), libwallet::Err
 
 		println!("checking account1 ...");
 		if api.set_active_account("account1").is_err() {
-			api.create_account_path("account1")?;
+			api.create_account("account1")?;
 			api.set_active_account("account1")?;
 		}
 		api.check_repair(true, 0, None)?;
 
 		println!("checking account2 ...");
 		if api.set_active_account("account2").is_err() {
-			api.create_account_path("account2")?;
+			api.create_account("account2")?;
 			api.set_active_account("account2")?;
 		}
 		api.check_repair(true, 0, None)?;
@@ -214,8 +214,8 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// wallet 1 create 2 more accounts but not used.
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.create_account_path("account1")?;
-		api.create_account_path("account2")?;
+		api.create_account("account1")?;
+		api.create_account("account2")?;
 		Ok(())
 	})?;
 
@@ -227,8 +227,8 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// wallet 2 will use another account
 	wallet::controller::owner_single_use(wallet2.clone(), |api| {
-		api.create_account_path("account1")?;
-		api.create_account_path("account2")?;
+		api.create_account("account1")?;
+		api.create_account("account2")?;
 		Ok(())
 	})?;
 
@@ -246,8 +246,8 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// wallet 3 create 2 more accounts but not used.
 	wallet::controller::owner_single_use(wallet3.clone(), |api| {
-		api.create_account_path("account1")?;
-		api.create_account_path("account2")?;
+		api.create_account("account1")?;
+		api.create_account("account2")?;
 		Ok(())
 	})?;
 

--- a/controller/tests/self_send.rs
+++ b/controller/tests/self_send.rs
@@ -69,8 +69,8 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// add some accounts
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
-		api.create_account_path("mining")?;
-		api.create_account_path("listener")?;
+		api.create_account("mining")?;
+		api.create_account("listener")?;
 		Ok(())
 	})?;
 

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -349,7 +349,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 		let recipient_key = api.get_recipient_key()?;
 		wallet2_recipient_addr = Address::from_pubkey(
 			&recipient_key.recipient_pub_key,
-			&recipient_key.recipient_key_id,
+			recipient_key.recipient_key_id.last_path_index(),
 			true,
 		);
 		Ok(())

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -16,7 +16,8 @@
 use std::cell::RefCell;
 use std::{fs, path};
 
-// for writing storedtransaction files
+// for writing stored transaction files
+use rand::{thread_rng, Rng};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -32,6 +33,7 @@ use crate::keychain::{
 };
 use crate::store::{to_key, to_key_u64};
 
+use crate::core::address::Address;
 use crate::core::core::Transaction;
 use crate::core::{self, global};
 use crate::libwallet::{check_repair, check_repair_batch, restore, restore_batch};
@@ -185,9 +187,10 @@ where
 				.derive_keychain(global::is_floonet())
 				.context(ErrorKind::CallbackImpl("Error deriving keychain"))?,
 		);
-		// Initial a 'd3=0' key as the default recipient key. Configurable via `set_recipient_key` function.
-		self.set_recipient_key(self.config.recipient_keypath.unwrap_or(0))
-			.unwrap();
+		// Initial the recipient key if configured, otherwise use random last key path for it.
+		if let Some(recipient_keypath) = self.config.recipient_keypath {
+			self.set_recipient_key(recipient_keypath).unwrap();
+		}
 		Ok(())
 	}
 
@@ -204,20 +207,24 @@ where
 			return Err(ErrorKind::Backend("keychain is none".to_string()).into());
 		}
 		// Initialize the recipient key for non-interactive transaction.
-		let path = ExtKeychainPath::new(4, <u32>::max_value(), <u32>::max_value(), 0, keypath);
-		self.recipient_key_id = Some(Identifier::from_path(&path));
+		self.recipient_key_id = Some(self.parent_key_id.extend(keypath));
 		Ok(())
 	}
 
 	fn recipient_key(&self) -> Result<RecipientKey, Error> {
-		if self.keychain.is_none() || self.recipient_key_id.is_none() {
-			return Err(
-				ErrorKind::Backend("keychain or recipient_key_id is none".to_string()).into(),
-			);
+		if self.keychain.is_none() {
+			return Err(ErrorKind::Backend("keychain is none".to_string()).into());
 		}
 
 		let keychain = self.keychain_immutable();
-		let recipient_key_id = self.recipient_key_id.clone().unwrap();
+		let recipient_key_id = match &self.recipient_key_id {
+			Some(key_id) => key_id.clone(),
+			None => {
+				let mut last_path_index: u32 = thread_rng().gen();
+				last_path_index >>= 1;
+				self.parent_key_id.extend(last_path_index)
+			}
+		};
 		let recipient_pri_key = keychain.derive_key(&recipient_key_id).unwrap();
 		let recipient_pub_key =
 			PublicKey::from_secret_key(keychain.secp(), &recipient_pri_key).unwrap();
@@ -242,6 +249,53 @@ where
 			recipient_pub_key,
 			recipient_pri_key,
 		})
+	}
+
+	fn check_address(
+		&self,
+		addr: &Address,
+		d0_until: u32,
+		d1_until: u32,
+	) -> Result<AcctPathMapping, Error> {
+		if self.keychain.is_none() {
+			return Err(ErrorKind::Backend("keychain is none".to_string()).into());
+		}
+
+		let keychain = self.keychain_immutable();
+		let target_pub_key = addr.get_inner_pubkey();
+		let last_path = addr.get_key_id_last_path();
+
+		// searching the existing accounts firstly.
+		for acct_path in self.acct_path_iter() {
+			let key_id = addr.get_key_id(&acct_path.path);
+			let recipient_pub_key = keychain.derive_pub_key(&key_id)?;
+			if recipient_pub_key == target_pub_key {
+				return Ok(acct_path.clone());
+			}
+		}
+
+		// if not found, searching the first 10,000 possible accounts
+		info!(
+			"check_address: start searching the first {} possible accounts (until m/{}/{}) ...",
+			d0_until as u64 * d1_until as u64,
+			d0_until,
+			d1_until,
+		);
+		if let Ok(key_id) = keychain.search_pub_key(d0_until, d1_until, last_path, &target_pub_key)
+		{
+			info!("check_address: matching address found. key_id: {}", key_id);
+			Ok(AcctPathMapping {
+				label: "none".to_string(),
+				path: key_id,
+			})
+		} else {
+			info!("check_address: stop searching, no matching address found.");
+			Err(ErrorKind::Backend(format!(
+				"address checking stop at path m/{}/{}",
+				d0_until, d1_until
+			))
+			.into())
+		}
 	}
 
 	/// Close wallet and remove any stored credentials (TBD)

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -750,6 +750,15 @@ where
 		Ok(())
 	}
 
+	fn get_child_index(&mut self, parent_id: &Identifier) -> Result<u32, Error> {
+		let deriv_key = to_key(DERIV_PREFIX, &mut parent_id.to_bytes().to_vec());
+		let max_child_index = match self.db.borrow().as_ref().unwrap().get_ser(&deriv_key)? {
+			Some(t) => t,
+			None => 0,
+		};
+		Ok(max_child_index)
+	}
+
 	fn save_child_index(&mut self, parent_id: &Identifier, child_n: u32) -> Result<(), Error> {
 		let deriv_key = to_key(DERIV_PREFIX, &mut parent_id.to_bytes().to_vec());
 		self.db

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -46,13 +46,27 @@ where
 }
 
 /// new account path
-pub fn create_account_path<T: ?Sized, C, K>(w: &mut T, label: &str) -> Result<Identifier, Error>
+pub fn create_account<T: ?Sized, C, K>(w: &mut T, label: &str) -> Result<Identifier, Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
 	K: Keychain,
 {
-	keys::new_acct_path(&mut *w, label)
+	keys::new_acct(&mut *w, label)
+}
+
+/// new account path
+pub fn create_account_path<T: ?Sized, C, K>(
+	w: &mut T,
+	label: &str,
+	path: &Identifier,
+) -> Result<(), Error>
+where
+	T: WalletBackend<C, K>,
+	C: NodeClient,
+	K: Keychain,
+{
+	keys::new_acct_path(&mut *w, label, path)
 }
 
 /// set active account
@@ -260,6 +274,25 @@ where
 	K: Keychain,
 {
 	w.recipient_key_by_id(key_id)
+}
+
+/// Check whether an Address belongs to this wallet. If yes, return the corresponding account name and key id.
+/// Note:
+/// 1. This checking is NOT an exhausting check, which need '2^64' loops and is impractical.
+/// 2. This checking relys on the stored wallet accounts, if current existing accounts doesn't cover this
+/// address, it will automatically search the first 1,000 possible accounts.
+pub fn check_address<T: ?Sized, C, K>(
+	w: &mut T,
+	addr: &Address,
+	d0_until: u32,
+	d1_until: u32,
+) -> Result<AcctPathMapping, Error>
+where
+	T: WalletBackend<C, K>,
+	C: NodeClient,
+	K: Keychain,
+{
+	w.check_address(addr, d0_until, d1_until)
 }
 
 /// Construction of a non-interactive transaction output

--- a/libwallet/src/internal/keys.rs
+++ b/libwallet/src/internal/keys.rs
@@ -63,7 +63,7 @@ where
 }
 
 /// Adds an new parent account path with a given label
-pub fn new_acct_path<T: ?Sized, C, K>(wallet: &mut T, label: &str) -> Result<Identifier, Error>
+pub fn new_acct<T: ?Sized, C, K>(wallet: &mut T, label: &str) -> Result<Identifier, Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
@@ -101,6 +101,33 @@ where
 	batch.save_acct_path(save_path)?;
 	batch.commit()?;
 	Ok(return_id)
+}
+
+/// Adds an new parent account path with a given label
+pub fn new_acct_path<T: ?Sized, C, K>(
+	wallet: &mut T,
+	label: &str,
+	path: &Identifier,
+) -> Result<(), Error>
+where
+	T: WalletBackend<C, K>,
+	C: NodeClient,
+	K: Keychain,
+{
+	let label = label.to_owned();
+	if let Some(_) = wallet.acct_path_iter().find(|l| l.label == label) {
+		return Err(ErrorKind::AccountLabelAlreadyExists(label.clone()).into());
+	}
+
+	let save_path = AcctPathMapping {
+		label: label.to_owned(),
+		path: path.clone(),
+	};
+
+	let mut batch = wallet.batch()?;
+	batch.save_acct_path(save_path)?;
+	batch.commit()?;
+	Ok(())
 }
 
 /// Adds/sets a particular account path with a given label

--- a/libwallet/src/internal/restore.rs
+++ b/libwallet/src/internal/restore.rs
@@ -525,12 +525,13 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
+	let parent_path = wallet.parent_key_id();
 	let mut recipient_key_to_check = None;
 	if let Some(addr) = address_to_check {
 		// Check whether this address belongs to this wallet
 		let address = Address::from_str(&addr)?;
 		let mut is_mine = false;
-		if let Ok(recipient_key) = wallet.recipient_key_by_id(&address.get_key_id()) {
+		if let Ok(recipient_key) = wallet.recipient_key_by_id(&address.get_key_id(&parent_path)) {
 			if recipient_key.recipient_pub_key == address.get_inner_pubkey() {
 				is_mine = true;
 				recipient_key_to_check = Some(recipient_key);
@@ -582,12 +583,13 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
+	let parent_path = wallet.parent_key_id();
 	let mut recipient_key_to_check = None;
 	if let Some(addr) = address_to_check {
 		// Check whether this address belongs to this wallet
 		let address = Address::from_str(&addr)?;
 		let mut is_mine = false;
-		if let Ok(recipient_key) = wallet.recipient_key_by_id(&address.get_key_id()) {
+		if let Ok(recipient_key) = wallet.recipient_key_by_id(&address.get_key_id(&parent_path)) {
 			if recipient_key.recipient_pub_key == address.get_inner_pubkey() {
 				is_mine = true;
 				recipient_key_to_check = Some(recipient_key);

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -17,6 +17,7 @@
 //! implementation
 
 use crate::error::{Error, ErrorKind};
+use crate::gotts_core::address::Address;
 use crate::gotts_core::core::hash::Hash;
 use crate::gotts_core::core::{Output, Transaction, TxKernelApiEntry};
 use crate::gotts_core::libtx::{aggsig, secp_ser};
@@ -68,6 +69,18 @@ where
 
 	/// Return a recipient key by the key id
 	fn recipient_key_by_id(&self, key_id: &Identifier) -> Result<RecipientKey, Error>;
+
+	/// Check whether an Address belongs to this wallet. If yes, return the corresponding account name and key id.
+	/// Note:
+	/// 1. This checking is NOT an exhausting check, which need '2^64' loops and is impractical.
+	/// 2. This checking relys on the stored wallet accounts, if current existing accounts doesn't cover this
+	/// address, it will automatically search the first 1,000 possible accounts.
+	fn check_address(
+		&self,
+		addr: &Address,
+		d0_until: u32,
+		d1_until: u32,
+	) -> Result<AcctPathMapping, Error>;
 
 	/// Close wallet and remove any stored credentials (TBD)
 	fn close(&mut self) -> Result<(), Error>;

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -231,6 +231,9 @@ where
 	/// Delete data about an output from the backend
 	fn delete(&mut self, id: &Identifier, mmr_index: &Option<u64>) -> Result<(), Error>;
 
+	/// Get last stored child index of a given parent
+	fn get_child_index(&mut self, parent_id: &Identifier) -> Result<u32, Error>;
+
 	/// Save last stored child index of a given parent
 	fn save_child_index(&mut self, parent_key_id: &Identifier, child_n: u32) -> Result<(), Error>;
 

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -452,7 +452,27 @@ pub fn parse_address_args(args: &ArgMatches) -> Result<command::AddressArgs, Par
 	} else {
 		None
 	};
-	Ok(command::AddressArgs { address_to_check })
+	let d0 = parse_required(args, "d0")?;
+	let d0 = parse_u64(d0, "d0")?;
+	// Valid range: [0..2^31-1].
+	if d0 > (std::u32::MAX >> 1) as u64 {
+		return Err(ParseError::ArgumentError(
+			"valid range: [0..2^31-1]".to_string(),
+		));
+	}
+	let d1 = parse_required(args, "d1")?;
+	let d1 = parse_u64(d1, "d1")?;
+	// Valid range: [0..2^31-1].
+	if d1 > (std::u32::MAX >> 1) as u64 {
+		return Err(ParseError::ArgumentError(
+			"valid range: [0..2^31-1]".to_string(),
+		));
+	}
+	Ok(command::AddressArgs {
+		address_to_check,
+		d0_until: d0 as u32,
+		d1_until: d1 as u32,
+	})
 }
 
 pub fn parse_listen_args(

--- a/src/bin/gotts-wallet.yml
+++ b/src/bin/gotts-wallet.yml
@@ -391,3 +391,13 @@ subcommands:
             short: c
             long: check
             takes_value: true
+        - d0:
+            help: Search until 1st path reach a value. Valid range [0, 2^31-1].
+            long: d0
+            default_value: "100"
+            takes_value: true
+        - d1:
+            help: Search until 2nd path reach a value. Valid range [0, 2^31-1].
+            long: d1
+            default_value: "100"
+            takes_value: true

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -37,12 +37,12 @@ dirs = "1.0.3"
 #gotts_store = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5-beta.1" }
 
 # For bleeding edge
-gotts_core = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
-gotts_keychain = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
-gotts_chain = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
-gotts_util = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
-gotts_api = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
-gotts_store = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
+gotts_core = { git = "https://github.com/gottstech/gotts", rev = "1d61c14" }
+gotts_keychain = { git = "https://github.com/gottstech/gotts", rev = "1d61c14" }
+gotts_chain = { git = "https://github.com/gottstech/gotts", rev = "1d61c14" }
+gotts_util = { git = "https://github.com/gottstech/gotts", rev = "1d61c14" }
+gotts_api = { git = "https://github.com/gottstech/gotts", rev = "1d61c14" }
+gotts_store = { git = "https://github.com/gottstech/gotts", rev = "1d61c14" }
 
 # For local testing
 #gotts_core = { path = "../../gotts/core"}

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -37,12 +37,12 @@ dirs = "1.0.3"
 #gotts_store = { git = "https://github.com/gottstech/gotts", tag = "v0.0.5-beta.1" }
 
 # For bleeding edge
-gotts_core = { git = "https://github.com/gottstech/gotts", rev = "769498d" }
-gotts_keychain = { git = "https://github.com/gottstech/gotts", rev = "769498d" }
-gotts_chain = { git = "https://github.com/gottstech/gotts", rev = "769498d" }
-gotts_util = { git = "https://github.com/gottstech/gotts", rev = "769498d" }
-gotts_api = { git = "https://github.com/gottstech/gotts", rev = "769498d" }
-gotts_store = { git = "https://github.com/gottstech/gotts", rev = "769498d" }
+gotts_core = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
+gotts_keychain = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
+gotts_chain = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
+gotts_util = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
+gotts_api = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
+gotts_store = { git = "https://github.com/gottstech/gotts", rev = "afae264" }
 
 # For local testing
 #gotts_core = { path = "../../gotts/core"}


### PR DESCRIPTION
(The related PR in node: https://github.com/gottstech/gotts/pull/41)

This refactoring include the following parts:

1. As default, wallet receiving address will use random address, i.e. each time when running `address` command, it will give a random Gotts address. The `random` comes from the random last path index for the current active wallet account. Say, current active wallet account is `m/p1/p2`, then, the final key id is `m/p1/p2/random`. This can help to improve the non-interactive transaction privacy.

2. The new designed `address --check`  command. It will search all existing wallet accounts to match the specified address. And if failed, it will further search the wallet possible accounts from `m/0/0` until `m/100/100` as default, if found the matched address, it will automatically create corresponding account into this wallet. And the searching range can be specified by user, with parameter `--d0` and `--d1`. For example:  `address --check a-gotts-address-string --d0 10 --d1 1000` will search from `m/0/0` until `m/10/1000`.



