### PR TITLE
fix: group_by only group consecutive elements

### DIFF
--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -514,15 +514,16 @@ where
 	}
 
 	{
-		let siglocked_coins: Vec<OutputData> = coins
+		let mut siglocked_coins: Vec<OutputData> = coins
 			.clone()
 			.drain(..)
 			.filter(|c| c.p2pkh.is_some())
 			.collect();
 		if siglocked_coins.len() > 0 {
+			siglocked_coins.sort_by_key(|x| x.p2pkh);
 			let grouped = siglocked_coins
 				.iter()
-				.group_by(|&coin| coin.p2pkh.unwrap())
+				.group_by(|&coin| coin.p2pkh)
 				.into_iter()
 				.map(|(_k, group)| group.cloned().collect())
 				.collect::<Vec<Vec<OutputData>>>();


### PR DESCRIPTION
The fix in https://github.com/gottstech/gotts-wallet/pull/17 is not 100% completed.

Read the `group_by` function document:
```Text
/// Return an *iterable* that can group iterator elements.
/// Consecutive elements that map to the same key (“runs”), are assigned
/// to the same group.
```
and I just saw the `Consecutive` keyword :-)  that means it will only group the consecutive elements, so we need a `sort` before calling `group_by`.

